### PR TITLE
feat(sweeps): add DTO and interfaces for sweep operations

### DIFF
--- a/src/modules/sweeps/dto/execute-sweep.dto.ts
+++ b/src/modules/sweeps/dto/execute-sweep.dto.ts
@@ -1,0 +1,9 @@
+export interface ExecuteSweepDto {
+  accountId: string;
+  ephemeralPublicKey: string;
+  ephemeralSecret: string;
+  destinationAddress: string;
+  amount: string;
+  asset: string;
+}
+

--- a/src/modules/sweeps/interfaces/authorize-sweep-params.interface.ts
+++ b/src/modules/sweeps/interfaces/authorize-sweep-params.interface.ts
@@ -1,0 +1,4 @@
+export interface AuthorizeSweepParams {
+  ephemeralPublicKey: string;
+  destinationAddress: string;
+}

--- a/src/modules/sweeps/interfaces/contract-auth-result.interface.ts
+++ b/src/modules/sweeps/interfaces/contract-auth-result.interface.ts
@@ -1,0 +1,5 @@
+export interface ContractAuthResult {
+  authorized: boolean;
+  hash: string;
+  timestamp: Date;
+}

--- a/src/modules/sweeps/interfaces/execute-transaction-params.interface.ts
+++ b/src/modules/sweeps/interfaces/execute-transaction-params.interface.ts
@@ -1,0 +1,6 @@
+export interface ExecuteTransactionParams {
+  ephemeralSecret: string;
+  destinationAddress: string;
+  amount: string;
+  asset: string;
+}

--- a/src/modules/sweeps/interfaces/merge-account-params.interface.ts
+++ b/src/modules/sweeps/interfaces/merge-account-params.interface.ts
@@ -1,0 +1,4 @@
+export interface MergeAccountParams {
+  ephemeralSecret: string;
+  destinationAddress: string;
+}

--- a/src/modules/sweeps/interfaces/sweep-result.interface.ts
+++ b/src/modules/sweeps/interfaces/sweep-result.interface.ts
@@ -1,0 +1,8 @@
+export interface SweepResult {
+  success: boolean;
+  txHash: string;
+  contractAuthHash: string;
+  amountSwept: string;
+  destination: string;
+  timestamp: Date;
+}

--- a/src/modules/sweeps/interfaces/transaction-result.interface.ts
+++ b/src/modules/sweeps/interfaces/transaction-result.interface.ts
@@ -1,0 +1,6 @@
+export interface TransactionResult {
+  hash: string;
+  ledger: number;
+  successful: boolean;
+  timestamp: Date;
+}


### PR DESCRIPTION
Description This PR adds the TypeScript DTO and interface definitions required to implement the sweeps workflow in the sweeps module. The new types capture request parameters and result shapes for: contract authorization, executing transactions, merging ephemeral accounts, and returning sweep/transaction results.

Changed files

execute-sweep.dto.ts — DTO for incoming execute-sweep requests (accountId, ephemeral keys, destination, amount, asset).
authorize-sweep-params.interface.ts — params used to authorize a sweep (ephemeral public key, destination).
contract-auth-result.interface.ts — result shape for contract authorization.
execute-transaction-params.interface.ts — params to execute a payment transaction.
merge-account-params.interface.ts — params for merging an ephemeral account into destination.
sweep-result.interface.ts — final sweep outcome shape.
transaction-result.interface.ts — on-chain transaction result shape (hash, ledger, success, timestamp).
Why

Provides a typed contract for upcoming sweeps implementation in the service/controller.
Improves compile-time safety and makes future integration/tests easier.
How to verify

Run TypeScript typecheck/build:
npm run build (or tsc)
Run test suite:
npm test
Confirm no new lint/type errors and that these types are importable from the sweeps module.
Backward compatibility / migration

Types only; no behavior or API surface changes. Safe to merge.
Notes / Next steps

Implement the sweeps service/controller logic using these types (authorize -> execute transaction -> merge account -> return SweepResult).
Add unit/integration tests exercising the full sweep flow and error cases.
Reviewers

sweep module maintainers / backend team
Completion checklist

 Type-checks cleanly
 Tests pass (if any rely on these types)
 README/docs updated later if public API changes
If you'd like, I can also:

run a local typecheck/build and report results, or
open the PR draft with this description (if you provide remote access details). Which next step do you want?
GPT-5 mini • 1x