### PR TITLE
Created claim entity

### DIFF
--- a/src/modules/claims/dto/claim-redemption-response.dto.ts
+++ b/src/modules/claims/dto/claim-redemption-response.dto.ts
@@ -1,0 +1,46 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class ClaimRedemptionResponseDto {
+  @ApiProperty({
+    example: true,
+    description: 'Whether the claim redemption was successful',
+  })
+  success: boolean;
+
+  @ApiProperty({
+    example: '1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
+    description: 'The Stellar transaction hash of the redemption',
+  })
+  txHash: string;
+
+  @ApiProperty({
+    example: '100.0000000',
+    description: 'The amount that was transferred to the destination address',
+  })
+  amountSwept: string;
+
+  @ApiProperty({
+    example: 'native',
+    description: 'The asset identifier that was transferred',
+  })
+  asset: string;
+
+  @ApiProperty({
+    example: 'GBBD47UZQ5YLQYYTWTCB7X3DUEEVZMDVGFBRNZPMZDWQWKCFN3EOZQKQ',
+    description: 'The destination Stellar wallet address that received the funds',
+  })
+  destination: string;
+
+  @ApiProperty({
+    example: '2026-01-21T15:45:30Z',
+    description: 'The timestamp when the claim was redeemed and funds were swept',
+  })
+  sweptAt: Date;
+
+  @ApiProperty({
+    example: 'Claim successfully redeemed and funds transferred',
+    required: false,
+    description: 'Optional additional message about the redemption',
+  })
+  message?: string;
+}

--- a/src/modules/claims/dto/claim-verification-response.dto.ts
+++ b/src/modules/claims/dto/claim-verification-response.dto.ts
@@ -1,0 +1,33 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class ClaimVerificationResponseDto {
+  @ApiProperty({
+    example: true,
+    description: 'Whether the claim token is valid and can be redeemed',
+  })
+  valid: boolean;
+
+  @ApiProperty({
+    example: '4ebae33b-5b93-424c-858d-d79afc708af5',
+    description: 'The account ID associated with the claim token',
+  })
+  accountId: string;
+
+  @ApiProperty({
+    example: '100.0000000',
+    description: 'The amount that can be claimed',
+  })
+  amount: string;
+
+  @ApiProperty({
+    example: 'native',
+    description: 'The asset identifier (e.g., "native" or "USDC:GBUQWP3BOUZX34ULNQG23RQ6F4BFSRXVZ6GM2FYCVJW5M2D4D811E4B2")',
+  })
+  asset: string;
+
+  @ApiProperty({
+    example: '2026-02-21T10:30:00Z',
+    description: 'The timestamp when the claim token expires',
+  })
+  expiresAt: Date;
+}

--- a/src/modules/claims/dto/redeem-claim.dto.ts
+++ b/src/modules/claims/dto/redeem-claim.dto.ts
@@ -1,0 +1,35 @@
+import { ApiProperty } from '@nestjs/swagger';
+import {
+  IsString,
+  IsNotEmpty,
+  Matches,
+} from 'class-validator';
+
+export class RedeemClaimDto {
+  @ApiProperty({
+    example: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhY2NvdW50SWQiOiI0ZWJhZTMzYi01YjkzLTQyNGMtODU4ZC1kNzlhZmM3MDhhZjUiLCJjbGFpbVRva2VuSGFzaCI6ImQzZjJhMjhjOWE5YzQ5NTQ2MzA0YWE3ZjA4YmQ2YjkxIn0.P7z6qW8xYzK3mN2vP5rS9tU4vW1xY3zK7mN9oP2qR5',
+    description: 'JWT claim token extracted from the claim URL',
+  })
+  @IsString({
+    message: 'claimToken must be a string',
+  })
+  @IsNotEmpty({
+    message: 'claimToken is required',
+  })
+  claimToken: string;
+
+  @ApiProperty({
+    example: 'GBBD47UZQ5YLQYYTWTCB7X3DUEEVZMDVGFBRNZPMZDWQWKCFN3EOZQKQ',
+    description: 'Stellar wallet address to receive funds. Must start with G and be exactly 56 characters',
+  })
+  @IsString({
+    message: 'destinationAddress must be a string',
+  })
+  @IsNotEmpty({
+    message: 'destinationAddress is required',
+  })
+  @Matches(/^G[A-Z0-9]{55}$/, {
+    message: 'destinationAddress must be a valid Stellar address (starts with G and is 56 characters long)',
+  })
+  destinationAddress: string;
+}

--- a/src/modules/claims/dto/verify-claim.dto.ts
+++ b/src/modules/claims/dto/verify-claim.dto.ts
@@ -1,0 +1,16 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsString, IsNotEmpty } from 'class-validator';
+
+export class VerifyClaimDto {
+  @ApiProperty({
+    example: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhY2NvdW50SWQiOiI0ZWJhZTMzYi01YjkzLTQyNGMtODU4ZC1kNzlhZmM3MDhhZjUiLCJjbGFpbVRva2VuSGFzaCI6ImQzZjJhMjhjOWE5YzQ5NTQ2MzA0YWE3ZjA4YmQ2YjkxIn0.P7z6qW8xYzK3mN2vP5rS9tU4vW1xY3zK7mN9oP2qR5',
+    description: 'JWT claim token extracted from the claim URL',
+  })
+  @IsString({
+    message: 'claimToken must be a string',
+  })
+  @IsNotEmpty({
+    message: 'claimToken is required',
+  })
+  claimToken: string;
+}

--- a/src/modules/claims/entities/claim.entity.ts
+++ b/src/modules/claims/entities/claim.entity.ts
@@ -1,0 +1,47 @@
+import {
+  Entity,
+  Column,
+  PrimaryGeneratedColumn,
+  CreateDateColumn,
+  UpdateDateColumn,
+  ManyToOne,
+  JoinColumn,
+  Index,
+} from 'typeorm';
+import { Account } from '../../accounts/entities/account.entity.js';
+
+@Entity('claims')
+@Index(['accountId'])
+export class Claim {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'uuid' })
+  @Index()
+  accountId: string;
+
+  @ManyToOne(() => Account, { eager: false, onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'accountId' })
+  account: Account;
+
+  @Column({ type: 'varchar', length: 56 })
+  destinationAddress: string;
+
+  @Column({ type: 'varchar', length: 64 })
+  sweepTxHash: string;
+
+  @Column({ type: 'varchar', length: 100 })
+  amountSwept: string;
+
+  @Column({ type: 'varchar', length: 100 })
+  asset: string;
+
+  @Column({ type: 'timestamp' })
+  claimedAt: Date;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}


### PR DESCRIPTION
The Created  Claims Entity and Request/Response DTOs 


Description


We need to create the database entity and Data Transfer Objects (DTOs) for the claims module. This will establish the foundation for claim token verification and redemption functionality.

Tasks
Create Claims Entity (src/modules/claims/entities/claim.entity.ts)
Create a TypeORM entity with the following specifications:
Fields:
id - Primary key (UUID, auto-generated)
accountId - Foreign key to Account entity (UUID, required)
account - ManyToOne relationship to Account entity
destinationAddress - Stellar public key where funds were sent (string, required)
sweepTxHash - Stellar transaction hash of the sweep operation (string, required)
amountSwept - Amount that was transferred (string, required)
asset - Asset identifier (e.g., "native" or "USDC:G...") (string, required)
claimedAt - Timestamp when claim was redeemed (Date, required)


Use class-validator decorators (@IsString, @isnotempty)
Add Swagger/OpenAPI decorators (@ApiProperty) with descriptive examples
Include proper validation messages

Example Swagger documentation:
@ApiProperty({
example: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...',
description: 'JWT claim token extracted from the claim URL'
})

Create RedeemClaimDto (src/modules/claims/dto/redeem-claim.dto.ts)
This DTO handles the claim redemption request.
Fields:
claimToken - The JWT token (string, required)
destinationAddress - Stellar wallet address to receive funds (string, required, must start with 'G' and be 56 characters)

Requirements:

Use class-validator decorators with custom validation for Stellar address format
Add Swagger documentation with examples
Validate that destinationAddress starts with 'G' and has exactly 56 characters

Create ClaimVerificationResponseDto (src/modules/claims/dto/claim-verification-response.dto.ts)
This DTO represents the response after verifying a claim token.
Fields:
valid - Whether the token is valid (boolean, required)
accountId - The associated account ID (string, required)
amount - Claimable amount (string, required)
asset - Asset identifier (string, required)
expiresAt - When the claim expires (Date, required)
Requirements:

Add Swagger documentation with realistic examples
No validation needed (response DTO)

Create ClaimRedemptionResponseDto (src/modules/claims/dto/claim-redemption-response.dto.ts)
This DTO represents the response after successfully redeeming a claim.
Fields:
success - Whether redemption succeeded (boolean, required)
txHash - Stellar transaction hash (string, required)
amountSwept - Amount transferred (string, required)
asset - Asset identifier (string, required)
destination - Destination wallet address (string, required)
sweptAt - Timestamp of sweep (Date, required)
message - Optional additional message (string, optional)
Requirements:

Add comprehensive Swagger documentation
Make message field optional with proper decorator

Acceptance Criteria


Claims entity created with all specified fields and proper TypeORM decorators

Index on accountId is properly configured

ManyToOne relationship to Account entity is correctly set up

All 4 DTOs are created with proper validation decorators

Swagger/OpenAPI documentation is complete with examples for all DTOs

Stellar address validation is implemented for destinationAddress

All files are placed in the correct directories

Code follows the project's TypeScript and NestJS conventions

Imports use .js extensions for ES modules compatibility
Notes

Refer to the existing Account entity for relationship setup patterns
Use @IsString(), @isnotempty(), @isboolean(), @matches() decorators from class-validator
For Stellar address validation, use: @matches(/^G[A-Z0-9]{55}$/) pattern
Ensure all DTOs export their classes properly
Do not implement any business logic - this issue is purely for data structures