### PR TITLE
feat: Implement Claim Lookup Provider for Retrieving Claim Details

### DIFF
--- a/src/modules/claims/claims.controller.ts
+++ b/src/modules/claims/claims.controller.ts
@@ -1,0 +1,34 @@
+import { Controller, Get, Param } from '@nestjs/common';
+import {
+  ApiOperation,
+  ApiResponse,
+  ApiTags,
+  ApiParam,
+} from '@nestjs/swagger';
+import { ClaimsService } from './claims.service.js';
+import { ClaimDetailsDto } from './dto/claim-details.dto.js';
+
+@ApiTags('claims')
+@Controller('claims')
+export class ClaimsController {
+  constructor(private readonly claimsService: ClaimsService) {}
+
+  @Get(':id')
+  @ApiOperation({ summary: 'Get claim details by ID' })
+  @ApiParam({
+    name: 'id',
+    description: 'Claim UUID',
+    type: 'string',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Claim details retrieved',
+    type: ClaimDetailsDto,
+  })
+  @ApiResponse({ status: 404, description: 'Claim not found' })
+  public async findOne(
+    @Param('id') id: string,
+  ): Promise<ClaimDetailsDto> {
+    return this.claimsService.findClaimById(id);
+  }
+}

--- a/src/modules/claims/claims.module.ts
+++ b/src/modules/claims/claims.module.ts
@@ -1,0 +1,21 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { ClaimsController } from './claims.controller.js';
+import { ClaimsService } from './claims.service.js';
+import { Claim } from './entities/claim.entity.js';
+import { Account } from '../accounts/entities/account.entity.js';
+
+import { ClaimLookupProvider } from './providers/claim-lookup.provider.js';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([Claim, Account]),
+  ],
+  controllers: [ClaimsController],
+  providers: [
+    ClaimsService,
+    ClaimLookupProvider,
+  ],
+  exports: [ClaimsService],
+})
+export class ClaimsModule {}

--- a/src/modules/claims/claims.service.ts
+++ b/src/modules/claims/claims.service.ts
@@ -1,0 +1,14 @@
+import { Injectable } from '@nestjs/common';
+import { ClaimLookupProvider } from './providers/claim-lookup.provider.js';
+import { ClaimDetailsDto } from './dto/claim-details.dto.js';
+
+@Injectable()
+export class ClaimsService {
+  constructor(
+    private readonly claimLookupProvider: ClaimLookupProvider,
+  ) {}
+
+  public async findClaimById(id: string): Promise<ClaimDetailsDto> {
+    return this.claimLookupProvider.findClaimById(id);
+  }
+}

--- a/src/modules/claims/dto/claim-details.dto.ts
+++ b/src/modules/claims/dto/claim-details.dto.ts
@@ -1,0 +1,46 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class ClaimDetailsDto {
+  @ApiProperty({
+    example: '550e8400-e29b-41d4-a716-446655440000',
+    description: 'Claim ID',
+  })
+  id: string;
+
+  @ApiProperty({
+    example: '660e8400-e29b-41d4-a716-446655440000',
+    description: 'Associated account ID',
+  })
+  accountId: string;
+
+  @ApiProperty({
+    example: 'GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5',
+    description: 'Destination wallet address',
+  })
+  destinationAddress: string;
+
+  @ApiProperty({
+    example: '100.0000000',
+    description: 'Amount that was swept',
+  })
+  amountSwept: string;
+
+  @ApiProperty({
+    example: 'USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5',
+    description: 'Asset identifier',
+  })
+  asset: string;
+
+  @ApiProperty({
+    example:
+      '571a84bc59fefb3fd17fe167b9c76286e83c31972649441a2d09da87f5b997a7',
+    description: 'Stellar transaction hash of the sweep',
+  })
+  sweepTxHash: string;
+
+  @ApiProperty({
+    example: '2026-01-14T17:49:20.265Z',
+    description: 'Timestamp when claim was redeemed',
+  })
+  claimedAt: Date;
+}

--- a/src/modules/claims/providers/claim-lookup.provider.ts
+++ b/src/modules/claims/providers/claim-lookup.provider.ts
@@ -1,0 +1,41 @@
+import { Injectable, NotFoundException, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Claim } from '../entities/claim.entity.js';
+import { ClaimDetailsDto } from '../dto/claim-details.dto.js';
+
+@Injectable()
+export class ClaimLookupProvider {
+  private readonly logger = new Logger(ClaimLookupProvider.name);
+
+  constructor(
+    @InjectRepository(Claim)
+    private readonly claimsRepository: Repository<Claim>,
+  ) {}
+
+  async findClaimById(id: string): Promise<ClaimDetailsDto> {
+    this.logger.log(`Looking up claim: ${id}`);
+
+    const claim = await this.claimsRepository.findOne({
+      where: { id },
+      relations: ['account'],
+    });
+
+    if (!claim) {
+      this.logger.warn(`Claim ${id} not found`);
+      throw new NotFoundException(`Claim ${id} not found`);
+    }
+
+    this.logger.log(`Claim ${id} retrieved successfully`);
+
+    return {
+      id: claim.id,
+      accountId: claim.accountId,
+      destinationAddress: claim.destinationAddress,
+      amountSwept: claim.amountSwept,
+      asset: claim.asset,
+      sweepTxHash: claim.sweepTxHash,
+      claimedAt: claim.claimedAt,
+    };
+  }
+}


### PR DESCRIPTION
Hey Maintainer 👋

I've successfully implemented the Claim Lookup Provider feature. The implementation is ready for review! closes #5

✅ ClaimLookupProvider - Fetches claims by ID with proper error handling
✅ ClaimDetailsDto - Complete Swagger documentation with examples
✅ GET /claims/:id endpoint - Fully functional and documented
✅ Proper logging - Because we're professionals here
✅ Error handling - 404s when claims don't exist (as they should)
✅ Clean code - No sensitive data exposed, ES modules conventions followed
✅ TypeORM relations - Account data loaded like a charm

Files Modified:
`src/modules/claims/providers/claim-lookup.provider.ts`
`src/modules/claims/dto/claim-details.dto.ts`
`src/modules/claims/claims.service.ts`
`src/modules/claims/claims.controller.ts`
`src/modules/claims/claims.module.ts`

P.S. - If this implementation is fire 🔥, I accept compliments 😊🙏


