### PR TITLE
fix: updated claim redemption provider to include temporary workarounds for missing WebhooksService

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,36 @@
 
 The Bridgelet SDK is a NestJS-based backend service that manages the lifecycle of ephemeral Stellar accounts. It handles account creation, claim authentication, webhook notifications, and integration with the bridgelet-core smart contracts.
 
+---
+
+## ⚠️ TEMPORARY DEVELOPMENT WORKAROUNDS (IMPORTANT)
+
+**PLEASE READ THIS SECTION BEFORE DEVELOPMENT**
+
+The following services/imports are currently **commented out** to allow `npm run start:dev` to run without errors. These are **NOT removed** and **MUST be restored** once proper implementations exist.
+
+### Missing Services:
+
+1. **WebhooksService** (referenced in `src/modules/claims/providers/claim-redemption.provider.ts`)
+   - **Location:** `src/modules/webhooks/` (does not exist yet)
+   - **What was commented out:**
+     - Constructor dependency injection (line ~25)
+     - Webhook trigger for `sweep.completed` event (line ~106)
+     - Webhook trigger for `sweep.failed` event (line ~137)
+   - **Why:** Service implementation does not exist, causing TypeScript compilation errors
+   - **Impact:** Webhook notifications will NOT fire when claims are redeemed or when sweeps fail
+   - **Restoration required:** Once `WebhooksService` is implemented in `src/modules/webhooks/`, uncomment all marked sections
+
+### How to Find Temporary Changes:
+
+Search the codebase for comments containing `TEMPORARY:` to locate all commented-out code that needs restoration.
+
+### Status:
+
+This is a **temporary stabilization** to enable local development and onboarding until missing implementations are complete. **No code was deleted** - all logic remains in place as comments.
+
+---
+
 ## Tech Stack
 
 - **Framework:** NestJS (Node.js + TypeScript)

--- a/src/modules/claims/providers/claim-redemption.provider.ts
+++ b/src/modules/claims/providers/claim-redemption.provider.ts
@@ -22,7 +22,8 @@ export class ClaimRedemptionProvider {
     private accountsRepository: Repository<Account>,
     private tokenVerificationProvider: TokenVerificationProvider,
     private sweepsService: SweepsService,
-    private webhooksService: WebhooksService,
+    // TEMPORARY: WebhooksService not yet implemented - commented out to allow dev server to start
+    // private webhooksService: WebhooksService,
   ) {}
 
   async redeemClaim(
@@ -102,16 +103,16 @@ export class ClaimRedemptionProvider {
 
       this.logger.log(`Claim redeemed successfully: ${claim.id}`);
 
-      // Fire webhook
-      await this.webhooksService.triggerEvent('sweep.completed', {
-        accountId: account.id,
-        amount: account.amount,
-        asset: account.asset,
-        destination: destinationAddress,
-        txHash: sweepResult.txHash,
-        sweptAt: claim.claimedAt,
-        metadata: account.metadata,
-      });
+      // TEMPORARY: WebhooksService not yet implemented - webhook trigger commented out
+      // await this.webhooksService.triggerEvent('sweep.completed', {
+      //   accountId: account.id,
+      //   amount: account.amount,
+      //   asset: account.asset,
+      //   destination: destinationAddress,
+      //   txHash: sweepResult.txHash,
+      //   sweptAt: claim.claimedAt,
+      //   metadata: account.metadata,
+      // });
 
       return {
         success: true,
@@ -133,15 +134,15 @@ export class ClaimRedemptionProvider {
         error.stack,
       );
 
-      // Fire webhook for failed sweep
-      await this.webhooksService.triggerEvent('sweep.failed', {
-        accountId: account.id,
-        amount: account.amount,
-        asset: account.asset,
-        destination: destinationAddress,
-        error: error.message,
-        timestamp: new Date(),
-      });
+      // TEMPORARY: WebhooksService not yet implemented - webhook trigger commented out
+      // await this.webhooksService.triggerEvent('sweep.failed', {
+      //   accountId: account.id,
+      //   amount: account.amount,
+      //   asset: account.asset,
+      //   destination: destinationAddress,
+      //   error: error.message,
+      //   timestamp: new Date(),
+      // });
 
       throw error;
     }


### PR DESCRIPTION
# :wrench: Add temporary workarounds for missing WebhooksService

- [x] Closes #28

---

### 📌 Type of Change

- [x] Documented temporary development workarounds in README
- [x] Commented out WebhooksService usage in claim redemption provider to unblock `npm run start:dev`
- [x] Added "TEMPORARY DEVELOPMENT WORKAROUNDS" section (missing services, restoration instructions, `TEMPORARY:` search hint)
- [x] Preserved webhook logic as comments for restoration once WebhooksService exists

**Files Changed:**

- `README.md`
- `src/modules/claims/providers/claim-redemption.provider.ts`
