### PR TITLE
Fix/issue 46 address validation in validation provider tests

### DIFF
--- a/src/modules/sweeps/providers/validation.provider.spec.ts
+++ b/src/modules/sweeps/providers/validation.provider.spec.ts
@@ -242,10 +242,3 @@ describe('ValidationProvider', () => {
     });
   });
 });
-
-// This is a dummy test remove it after fix!!!
-// describe('ValidationProvider', () => {
-//   it('should be defined', () => {
-//     expect(true).toBe(true);
-//   });
-// });


### PR DESCRIPTION
Closes #46

---
All validation.provider.spec.ts features implemented

- [x]  All test code is uncommented

- [x] All Stellar addresses are exactly 56 characters

- [x] All addresses pass StrKey.isValidEd25519PublicKey() validation

- [x] All 14 tests pass successfully