### PR TITLE
Docs: Add service-level documentation & contributor guidance for AccountsService (#49)

### DIFF
--- a/src/modules/accounts/accounts.service.ts
+++ b/src/modules/accounts/accounts.service.ts
@@ -9,6 +9,82 @@ import { JwtService } from '@nestjs/jwt';
 import * as crypto from 'crypto';
 import { ConfigService } from '@nestjs/config';
 
+/**
+ * AccountsService — Service-Level Documentation & Contributor Guidance
+ *
+ * Lifecycle Overview
+ * ------------------
+ * This service is an orchestration layer in the Bridgelet flow responsible for
+ * ephemeral account creation, funding, claim-token lifecycle management,
+ * interaction with the `StellarService`, persistence of account state, and
+ * shaping API responses (`AccountResponseDto`). Typical flow:
+ *
+ * 1. Ephemeral account creation: a keypair is generated and an account is
+ *    provisioned/funded on the Stellar network via `StellarService`.
+ * 2. Claim generation: a claim token is produced and a hash of that token is
+ *    stored on the account record (the plain token is returned in the API
+ *    response only). The token is used by end-users to claim the funded
+ *    ephemeral account.
+ * 3. Claiming: an external request exchanges the token for the secret.
+ * 4. Post-claim: account status and destination fields are updated accordingly.
+ *
+ * Security Notes
+ * --------------
+ * - MVP placeholders: Several methods in this file include intentionally
+ *   lightweight or placeholder implementations that are NOT production secure.
+ *   These are clearly marked in the code. Examples include:
+ *     - `encryptSecret()` currently uses base64 for storage (NOT SECURE).
+ *     - Token signing uses the configured JWT secret; ensure the secret
+ *       management and rotation policies meet your security requirements.
+ *
+ * - Token handling: the service stores only a SHA-256 hash of the claim token
+ *   (`claimTokenHash`) rather than the raw token. The raw token is delivered
+ *   once to callers via the generated claim URL. Changes to token format,
+ *   signing algorithm, or expiry semantics are protocol-sensitive and will
+ *   break clients if not coordinated.
+ *
+ * - Secret storage: `secretKeyEncrypted` is intended to hold an encrypted
+ *   secret. Treat the current implementation as a placeholder. Do NOT
+ *   replace it with a new encoding/encryption scheme without documenting the
+ *   migration plan and ensuring compatibility for any live secrets.
+ *
+ * Integration Boundaries
+ * ----------------------
+ * - Assumptions about `StellarService`:
+ *     - It provides `generateKeypair()` and `createEphemeralAccount()` with
+ *       the semantics expected here (returning a transaction hash when
+ *       funding succeeds).
+ *     - The format of the public key and secret follow Stellar keypair
+ *       conventions; these assumptions are protocol-sensitive.
+ *
+ * - External integrators rely on stable response fields (e.g., `claimUrl`,
+ *   `publicKey`, `txHash`). Response shaping is backward-compatible by
+ *   design — avoid renaming or removing fields without a migration/compat
+ *   strategy.
+ *
+ * Mapping & DTO Intent
+ * --------------------
+ * - Response DTOs intentionally expose only a subset of stored fields. For
+ *   example, the raw `secret` is never returned; the `claimUrl` provides a
+ *   user-facing way to perform a claim without disclosing secrets.
+ * - Conditional fields: some response fields are conditionally populated
+ *   (e.g., `claimUrl` only when a claim token exists). Maintain these rules
+ *   when changing mapping logic to avoid leaking internal state.
+ *
+ * Contributor Guidance — Ask If Unsure
+ * -----------------------------------
+ * ⚠️ This service encodes protocol-level behavior. If you are unsure whether
+ * a change affects lifecycle guarantees, consult maintainers before modifying
+ * logic.
+ *
+ * If any behavior is unclear:
+ * - Check the repository README for architecture context.
+ * - Review the `docs/` directory for protocol expectations.
+ * - Ask before making assumptions, especially around: token generation,
+ *   expiry semantics, data exposure, or secret handling.
+ *
+ * When in doubt: document, do not redesign silently.
+ */
 @Injectable()
 export class AccountsService {
   constructor(
@@ -110,6 +186,20 @@ export class AccountsService {
   }
 
   private generateClaimToken(publicKey: string): string {
+    /**
+     * generateClaimToken
+     * ------------------
+     * Purpose: Sign a short-lived JWT that encodes the public key and a
+     * 'claim' type. The resulting token is handed to callers and is the
+     * secret used to claim the ephemeral account.
+     *
+     * Security notes / contributor guidance:
+     * - The token expiry (`app.claimTokenExpiry`) is protocol-sensitive.
+     *   Changing expiry semantics requires coordination with clients.
+     * - The JWT signing secret must be managed and rotated safely. Do not
+     *   switch to a different signing mechanism without an explicit design
+     *   and migration plan.
+     */
     // const secret =
     //   this.configService.get<string>('app.jwtSecret') ?? 'fallback secret';
     const expiry =
@@ -122,11 +212,25 @@ export class AccountsService {
   }
 
   private generateClaimUrl(token: string): string {
+    // generateClaimUrl
+    // ----------------
+    // Purpose: Build the user-facing URL used to perform the claim flow.
+    // Integration notes:
+    // - `CLAIM_BASE_URL` is an environment-level integration point. External
+    //   systems and email templates may rely on the shape of this URL.
     const baseUrl = process.env.CLAIM_BASE_URL || 'https://claim.bridgelet.io';
     return `${baseUrl}/c/${token}`;
   }
 
   private encryptSecret(secret: string): string {
+    // encryptSecret
+    // -------------
+    // WARNING: MVP placeholder — this must be replaced for production.
+    // - Current implementation: base64 encoding. This is NOT encryption and
+    //   should never be used to store secrets in production systems.
+    // - Recommended: use AES-256-GCM (or KMS-backed envelope encryption) and
+    //   manage keys with a secrets manager. If you change this, provide a
+    //   documented migration path for existing records.
     // TODO: Implement proper encryption (AES-256)
     // For MVP, using base64 (NOT SECURE for production)
     return Buffer.from(secret).toString('base64');
@@ -136,6 +240,10 @@ export class AccountsService {
     return {
       accountId: account.id,
       publicKey: account.publicKey,
+      // Mapping note: we intentionally never return raw tokens here.
+      // When a token exists, we return a placeholder claim URL in list/endpoints
+      // that shouldn't leak the real token. The single-response `create`
+      // operation returns the real `claimUrl` containing the token.
       claimUrl: account.claimTokenHash ? this.generateClaimUrl('***') : null,
       amount: account.amount,
       asset: account.asset,


### PR DESCRIPTION

## Changes

- Added a comprehensive top‑level comment block to `AccountsService` explaining
  its role in the Bridgelet flow.
- Documented lifecycle steps (creation, funding, claim), security assumptions,
  integration boundaries, DTO/response‑mapping intent, and MVP placeholders.
- Inserted inline “security notes” and “ask if unsure” guidance throughout the
  file.
- No runtime logic modified; all additions are comments for maintainers.

## Testing

✅ Lint passed  
✅ Formatting (`npm run format:check`) passes after formatting  
✅ All 46 unit tests pass locally  
✅ Build completes without errors  