### PR TITLE
Feature: Add getAccountInfo() and expireAccount() to StellarService (#79)

### DIFF
--- a/src/modules/stellar/stellar.service.spec.ts
+++ b/src/modules/stellar/stellar.service.spec.ts
@@ -1,0 +1,319 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import {
+  BadRequestException,
+  InternalServerErrorException,
+} from '@nestjs/common';
+import {
+  rpc,
+  Contract,
+  TransactionBuilder,
+  BASE_FEE,
+  Networks,
+  xdr,
+  Account,
+} from '@stellar/stellar-sdk';
+import { StellarService, AccountInfo } from './stellar.service.js';
+
+// ── Mocks ────────────────────────────────────────────────────────────────────
+
+const mockRpcServer = {
+  simulateTransaction: jest.fn(),
+  getLatestLedger: jest.fn(),
+  getAccount: jest.fn(),
+  sendTransaction: jest.fn(),
+};
+
+const mockContract = { call: jest.fn() };
+
+const mockTxBuilder = {
+  addOperation: jest.fn().mockReturnThis(),
+  setTimeout: jest.fn().mockReturnThis(),
+  build: jest.fn(),
+};
+
+const mockAssembledTxBuilder = {
+  build: jest.fn(),
+};
+
+jest.mock('@stellar/stellar-sdk', () => {
+  const actual = jest.requireActual<typeof import('@stellar/stellar-sdk')>(
+    '@stellar/stellar-sdk',
+  );
+  return {
+    ...actual,
+    Contract: jest.fn(() => mockContract),
+    rpc: {
+      ...actual.rpc,
+      Server: jest.fn(() => mockRpcServer),
+      Api: {
+        ...actual.rpc.Api,
+        isSimulationError: jest.fn(),
+      },
+      assembleTransaction: jest.fn(() => mockAssembledTxBuilder),
+    },
+    TransactionBuilder: jest.fn(() => mockTxBuilder),
+  };
+});
+
+// ── Valid test addresses (real Stellar keypairs) ──────────────────────────────
+
+const CREATOR_ADDR = 'GBFNL5K6HIHD3ZLZBX75P43LD3ZMJCUFJWIV63BEIC6VMBZ32SSR426Y';
+const RECOVERY_ADDR = 'GDCUA4MGMSR6UBHWUFPNPFVJOE2575FXRMIPLA47WJ3PEVXYUNMFMU4D';
+const SWEPT_TO_ADDR = 'GBFXKJJF4MYKYQQPUEWY3N7DZSI7IW4GGVFGFBVVIAVQITZO554ZJ5C3';
+// Valid Stellar secret key
+const FUNDING_SECRET = 'SBZBKSEXDKQ7NHWJDMF3S6LJH5B5YSIPY3ESUIWOSPUFAGYXUSFTZBVZ';
+const FUNDING_PUBLIC = 'GBBFBAMZ2GTJNCHAHTRZVUJWS5ZABRRTVIV4272Q77RP4HI6LYPXURQD';
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/** Build a minimal ScVal map that mimics get_info() return value */
+function buildAccountInfoScVal(overrides: Partial<{
+  status: string;
+  expiryLedger: number;
+  paymentReceived: boolean;
+  paymentCount: number;
+  sweptTo: string | null;
+}> = {}): xdr.ScVal {
+  const {
+    status = 'Active',
+    expiryLedger = 1000,
+    paymentReceived = false,
+    paymentCount = 0,
+    sweptTo = null,
+  } = overrides;
+
+  const actual = jest.requireActual<typeof import('@stellar/stellar-sdk')>(
+    '@stellar/stellar-sdk',
+  );
+
+  const entry = (key: string, val: xdr.ScVal) =>
+    new actual.xdr.ScMapEntry({ key: actual.xdr.ScVal.scvSymbol(key), val });
+
+  const sweptToVal = sweptTo
+    ? actual.xdr.ScVal.scvVec([actual.Address.fromString(sweptTo).toScVal()])
+    : actual.xdr.ScVal.scvVec([]);
+
+  return actual.xdr.ScVal.scvMap([
+    entry('creator', actual.Address.fromString(CREATOR_ADDR).toScVal()),
+    entry('status', actual.xdr.ScVal.scvVec([actual.xdr.ScVal.scvSymbol(status)])),
+    entry('expiry_ledger', actual.xdr.ScVal.scvU32(expiryLedger)),
+    entry('recovery_address', actual.Address.fromString(RECOVERY_ADDR).toScVal()),
+    entry('payment_received', actual.xdr.ScVal.scvBool(paymentReceived)),
+    entry('payment_count', actual.xdr.ScVal.scvU32(paymentCount)),
+    entry('payments', actual.xdr.ScVal.scvVec([])),
+    entry('swept_to', sweptToVal),
+  ]);
+}
+
+/** Stub AccountInfo returned by mocked getAccountInfo */
+const stubAccountInfo = (expiryLedger: number): AccountInfo => ({
+  creator: CREATOR_ADDR,
+  status: 'Active',
+  expiryLedger,
+  recoveryAddress: RECOVERY_ADDR,
+  paymentReceived: false,
+  paymentCount: 0,
+  payments: [],
+  sweptTo: null,
+});
+
+const CONTRACT_ID = 'CDUMMYCONTRACTID123456789ABCDEFGHIJKLMNOPQRSTUV';
+
+const mockConfig: Record<string, string> = {
+  'stellar.horizonUrl': 'https://horizon-testnet.stellar.org',
+  'stellar.network': 'testnet',
+  'stellar.sorobanRpcUrl': 'https://soroban-testnet.stellar.org',
+  'stellar.contracts.ephemeralAccount': CONTRACT_ID,
+  'stellar.fundingSecret': FUNDING_SECRET,
+};
+
+// ── Suite ─────────────────────────────────────────────────────────────────────
+
+describe('StellarService — getAccountInfo & expireAccount', () => {
+  let service: StellarService;
+  let mockTx: { sign: jest.Mock };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    mockTx = { sign: jest.fn() };
+    mockTxBuilder.build.mockReturnValue(mockTx);
+    mockAssembledTxBuilder.build.mockReturnValue(mockTx);
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        StellarService,
+        {
+          provide: ConfigService,
+          useValue: {
+            getOrThrow: jest.fn((key: string) => {
+              const v = mockConfig[key];
+              if (v === undefined) throw new Error(`Config not found: ${key}`);
+              return v;
+            }),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get<StellarService>(StellarService);
+  });
+
+  // ── getAccountInfo ──────────────────────────────────────────────────────────
+
+  describe('getAccountInfo', () => {
+    it('returns typed AccountInfo on success', async () => {
+      const retval = buildAccountInfoScVal({ status: 'Active', expiryLedger: 500 });
+
+      (rpc.Api.isSimulationError as unknown as jest.Mock).mockReturnValue(false);
+      mockRpcServer.simulateTransaction.mockResolvedValue({
+        result: { retval },
+        latestLedger: 100,
+      } as unknown as rpc.Api.SimulateTransactionSuccessResponse);
+
+      const info: AccountInfo = await service.getAccountInfo(CONTRACT_ID);
+
+      expect(info.status).toBe('Active');
+      expect(info.expiryLedger).toBe(500);
+      expect(info.paymentReceived).toBe(false);
+      expect(info.payments).toEqual([]);
+      expect(info.sweptTo).toBeNull();
+    });
+
+    it('uses simulateTransaction (no signing)', async () => {
+      const retval = buildAccountInfoScVal();
+      (rpc.Api.isSimulationError as unknown as jest.Mock).mockReturnValue(false);
+      mockRpcServer.simulateTransaction.mockResolvedValue({
+        result: { retval },
+        latestLedger: 100,
+      } as unknown as rpc.Api.SimulateTransactionSuccessResponse);
+
+      await service.getAccountInfo(CONTRACT_ID);
+
+      expect(mockRpcServer.simulateTransaction).toHaveBeenCalledTimes(1);
+      // sendTransaction must NOT be called for a read-only call
+      expect(mockRpcServer.sendTransaction).not.toHaveBeenCalled();
+    });
+
+    it('throws BadRequestException when contract is not initialized', async () => {
+      (rpc.Api.isSimulationError as unknown as jest.Mock).mockReturnValue(true);
+      mockRpcServer.simulateTransaction.mockResolvedValue({
+        error: 'Contract not initialized',
+      } as unknown as rpc.Api.SimulateTransactionErrorResponse);
+
+      await expect(service.getAccountInfo(CONTRACT_ID)).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+
+    it('throws InternalServerErrorException on RPC failure', async () => {
+      mockRpcServer.simulateTransaction.mockRejectedValue(new Error('RPC down'));
+
+      await expect(service.getAccountInfo(CONTRACT_ID)).rejects.toThrow(
+        InternalServerErrorException,
+      );
+    });
+
+    it('throws InternalServerErrorException when retval is missing', async () => {
+      (rpc.Api.isSimulationError as unknown as jest.Mock).mockReturnValue(false);
+      mockRpcServer.simulateTransaction.mockResolvedValue({
+        result: { retval: undefined },
+        latestLedger: 100,
+      } as unknown as rpc.Api.SimulateTransactionSuccessResponse);
+
+      await expect(service.getAccountInfo(CONTRACT_ID)).rejects.toThrow(
+        InternalServerErrorException,
+      );
+    });
+
+    it('parses sweptTo address when present', async () => {
+      const retval = buildAccountInfoScVal({ status: 'Swept', sweptTo: SWEPT_TO_ADDR });
+
+      (rpc.Api.isSimulationError as unknown as jest.Mock).mockReturnValue(false);
+      mockRpcServer.simulateTransaction.mockResolvedValue({
+        result: { retval },
+        latestLedger: 100,
+      } as unknown as rpc.Api.SimulateTransactionSuccessResponse);
+
+      const info = await service.getAccountInfo(CONTRACT_ID);
+      expect(info.status).toBe('Swept');
+      expect(info.sweptTo).toBe(SWEPT_TO_ADDR);
+    });
+  });
+
+  // ── expireAccount ───────────────────────────────────────────────────────────
+
+  describe('expireAccount', () => {
+    /**
+     * Spy on getAccountInfo so expireAccount tests are isolated from
+     * the ScVal parsing logic (already covered in getAccountInfo tests).
+     */
+    let getAccountInfoSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+      getAccountInfoSpy = jest.spyOn(service, 'getAccountInfo');
+    });
+
+    it('calls expire() and submits when ledger has passed expiry', async () => {
+      getAccountInfoSpy.mockResolvedValue(stubAccountInfo(500));
+      mockRpcServer.getLatestLedger.mockResolvedValue({ latestLedger: 600 });
+      mockRpcServer.getAccount.mockResolvedValue(new Account(FUNDING_PUBLIC, '1'));
+      (rpc.Api.isSimulationError as unknown as jest.Mock).mockReturnValue(false);
+      mockRpcServer.simulateTransaction.mockResolvedValue({
+        result: {},
+        latestLedger: 600,
+      } as unknown as rpc.Api.SimulateTransactionSuccessResponse);
+      mockRpcServer.sendTransaction.mockResolvedValue({ hash: 'abc' });
+
+      await service.expireAccount(CONTRACT_ID);
+
+      expect(mockRpcServer.sendTransaction).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns early (non-fatal) when current ledger < expiry_ledger', async () => {
+      getAccountInfoSpy.mockResolvedValue(stubAccountInfo(1000));
+      mockRpcServer.getLatestLedger.mockResolvedValue({ latestLedger: 500 });
+
+      await expect(service.expireAccount(CONTRACT_ID)).resolves.toBeUndefined();
+      expect(mockRpcServer.sendTransaction).not.toHaveBeenCalled();
+    });
+
+    it('returns early (non-fatal) when contract returns NotExpired', async () => {
+      getAccountInfoSpy.mockResolvedValue(stubAccountInfo(500));
+      mockRpcServer.getLatestLedger.mockResolvedValue({ latestLedger: 600 });
+      mockRpcServer.getAccount.mockResolvedValue(new Account(FUNDING_PUBLIC, '1'));
+      (rpc.Api.isSimulationError as unknown as jest.Mock).mockReturnValue(true);
+      mockRpcServer.simulateTransaction.mockResolvedValue({
+        error: 'Error::NotExpired',
+      } as unknown as rpc.Api.SimulateTransactionErrorResponse);
+
+      await expect(service.expireAccount(CONTRACT_ID)).resolves.toBeUndefined();
+      expect(mockRpcServer.sendTransaction).not.toHaveBeenCalled();
+    });
+
+    it('throws BadRequestException for InvalidStatus (terminal)', async () => {
+      getAccountInfoSpy.mockResolvedValue(stubAccountInfo(500));
+      mockRpcServer.getLatestLedger.mockResolvedValue({ latestLedger: 600 });
+      mockRpcServer.getAccount.mockResolvedValue(new Account(FUNDING_PUBLIC, '1'));
+      (rpc.Api.isSimulationError as unknown as jest.Mock).mockReturnValue(true);
+      mockRpcServer.simulateTransaction.mockResolvedValue({
+        error: 'Error::InvalidStatus',
+      } as unknown as rpc.Api.SimulateTransactionErrorResponse);
+
+      await expect(service.expireAccount(CONTRACT_ID)).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+
+    it('throws InternalServerErrorException on unexpected RPC error', async () => {
+      getAccountInfoSpy.mockResolvedValue(stubAccountInfo(500));
+      mockRpcServer.getLatestLedger.mockResolvedValue({ latestLedger: 600 });
+      mockRpcServer.getAccount.mockRejectedValue(new Error('RPC failure'));
+
+      await expect(service.expireAccount(CONTRACT_ID)).rejects.toThrow(
+        InternalServerErrorException,
+      );
+    });
+  });
+});

--- a/src/modules/stellar/stellar.service.ts
+++ b/src/modules/stellar/stellar.service.ts
@@ -1,18 +1,49 @@
-import { Injectable, Logger } from '@nestjs/common';
+import {
+  Injectable,
+  Logger,
+  InternalServerErrorException,
+  BadRequestException,
+} from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import * as StellarSdk from '@stellar/stellar-sdk';
+import { rpc, Contract, TransactionBuilder, BASE_FEE, Networks, xdr } from '@stellar/stellar-sdk';
+
+/** Mirrors the AccountInfo struct from bridgelet-core/shared/types.rs */
+export interface AccountInfo {
+  creator: string;
+  status: 'Active' | 'PaymentReceived' | 'Swept' | 'Expired';
+  expiryLedger: number;
+  recoveryAddress: string;
+  paymentReceived: boolean;
+  paymentCount: number;
+  payments: Array<{ asset: string; amount: string; timestamp: number }>;
+  sweptTo: string | null;
+}
 
 @Injectable()
 export class StellarService {
   private readonly logger = new Logger(StellarService.name);
   private server: StellarSdk.Horizon.Server;
+  private rpcServer: rpc.Server;
   private network: string;
+  private networkPassphrase: string;
+  private contractId: string;
 
   constructor(private configService: ConfigService) {
     const horizonUrl =
       this.configService.getOrThrow<string>('stellar.horizonUrl');
     this.network = this.configService.getOrThrow<string>('stellar.network');
     this.server = new StellarSdk.Horizon.Server(horizonUrl);
+
+    const sorobanRpcUrl = this.configService.getOrThrow<string>('stellar.sorobanRpcUrl');
+    this.rpcServer = new rpc.Server(sorobanRpcUrl);
+
+    this.networkPassphrase =
+      this.network === 'mainnet' ? Networks.PUBLIC : Networks.TESTNET;
+
+    this.contractId = this.configService.getOrThrow<string>(
+      'stellar.contracts.ephemeralAccount',
+    );
 
     this.logger.log(`Initialized Stellar service for ${this.network}`);
   }
@@ -33,8 +64,6 @@ export class StellarService {
       'stellar.fundingSecret',
     );
     const fundingKeypair = StellarSdk.Keypair.fromSecret(fundingSecret);
-
-    // console.log(`funding secret: ${fundingSecret}`);
 
     const fundingAccount = await this.server.loadAccount(
       fundingKeypair.publicKey(),
@@ -60,9 +89,206 @@ export class StellarService {
     return result.hash;
   }
 
+  /**
+   * Reads on-chain account state from the EphemeralAccount contract.
+   * Uses simulateTransaction (read-only) — no signing or fees required.
+   *
+   * NOTE: Fund recovery in expireAccount() depends on the token transfer
+   * implementation in the contract (currently a stub in bridgelet-core).
+   *
+   * @param contractId - The deployed EphemeralAccount contract address
+   * @returns Typed AccountInfo mirroring the Rust AccountInfo struct
+   * @throws InternalServerErrorException if the contract is not initialized or RPC fails
+   */
+  async getAccountInfo(contractId: string): Promise<AccountInfo> {
+    this.logger.log(`Fetching account info for contract: ${contractId}`);
+
+    try {
+      const contract = new Contract(contractId);
+
+      // Use a dummy source account for read-only simulation
+      const sourceKeypair = StellarSdk.Keypair.random();
+      const sourceAccount = new StellarSdk.Account(sourceKeypair.publicKey(), '0');
+
+      const transaction = new TransactionBuilder(sourceAccount, {
+        fee: BASE_FEE,
+        networkPassphrase: this.networkPassphrase,
+      })
+        .addOperation(contract.call('get_info'))
+        .setTimeout(30)
+        .build();
+
+      const simResult = await this.rpcServer.simulateTransaction(transaction);
+
+      if (rpc.Api.isSimulationError(simResult)) {
+        const msg = (simResult as rpc.Api.SimulateTransactionErrorResponse).error;
+        if (msg.includes('not initialized') || msg.includes('NotFound')) {
+          throw new BadRequestException(
+            `Contract ${contractId} is not initialized: ${msg}`,
+          );
+        }
+        throw new Error(`Simulation error: ${msg}`);
+      }
+
+      const successResult = simResult as rpc.Api.SimulateTransactionSuccessResponse;
+      const returnVal = successResult.result?.retval;
+
+      if (!returnVal) {
+        throw new Error('Contract returned no data — contract may not be initialized');
+      }
+
+      return this.parseAccountInfo(returnVal);
+    } catch (error) {
+      if (error instanceof BadRequestException) throw error;
+      const typedError = error as Error;
+      this.logger.error(`getAccountInfo failed: ${typedError.message}`, typedError.stack);
+      throw new InternalServerErrorException(
+        `Failed to get account info: ${typedError.message}`,
+      );
+    }
+  }
+
+  /**
+   * Expires an on-chain EphemeralAccount, returning funds to the recovery address.
+   * Calls EphemeralAccount.expire() on the contract.
+   *
+   * - Checks current ledger against expiry_ledger before invoking expire().
+   * - Error::NotExpired is treated as a non-fatal scheduling race condition.
+   * - Error::InvalidStatus is terminal (account already swept or expired).
+   *
+   * NOTE: Fund recovery depends on the token transfer implementation in the
+   * contract (currently a stub in bridgelet-core).
+   *
+   * @param contractId - The deployed EphemeralAccount contract address
+   * @throws BadRequestException for terminal contract errors (InvalidStatus)
+   * @throws InternalServerErrorException for RPC or unexpected failures
+   */
+  async expireAccount(contractId: string): Promise<void> {
+    this.logger.log(`Expiring account for contract: ${contractId}`);
+
+    try {
+      // Fetch on-chain state to check expiry_ledger before calling expire()
+      const info = await this.getAccountInfo(contractId);
+
+      const { latestLedger } = await this.rpcServer.getLatestLedger();
+
+      if (latestLedger < info.expiryLedger) {
+        // Non-fatal: scheduler called too early, not yet expired
+        this.logger.warn(
+          `Contract ${contractId} not yet expired. ` +
+          `Current ledger: ${latestLedger}, expiry ledger: ${info.expiryLedger}`,
+        );
+        return;
+      }
+
+      const fundingSecret = this.configService.getOrThrow<string>('stellar.fundingSecret');
+      const keypair = StellarSdk.Keypair.fromSecret(fundingSecret);
+      const account = await this.rpcServer.getAccount(keypair.publicKey());
+
+      const contract = new Contract(contractId);
+      const transaction = new TransactionBuilder(account, {
+        fee: BASE_FEE,
+        networkPassphrase: this.networkPassphrase,
+      })
+        .addOperation(contract.call('expire'))
+        .setTimeout(30)
+        .build();
+
+      transaction.sign(keypair);
+
+      const simResult = await this.rpcServer.simulateTransaction(transaction);
+
+      if (rpc.Api.isSimulationError(simResult)) {
+        const msg = (simResult as rpc.Api.SimulateTransactionErrorResponse).error;
+
+        if (msg.includes('NotExpired')) {
+          // Race condition: ledger advanced but contract disagrees — non-fatal
+          this.logger.warn(`Contract ${contractId} reports NotExpired — scheduling race condition`);
+          return;
+        }
+
+        if (msg.includes('InvalidStatus')) {
+          throw new BadRequestException(
+            `Cannot expire contract ${contractId}: account is already swept or expired`,
+          );
+        }
+
+        throw new Error(`Simulation error: ${msg}`);
+      }
+
+      const preparedTx = await rpc.assembleTransaction(
+        transaction,
+        simResult as rpc.Api.SimulateTransactionSuccessResponse,
+      ).build();
+
+      preparedTx.sign(keypair);
+      await this.rpcServer.sendTransaction(preparedTx);
+
+      this.logger.log(`Account expired successfully: ${contractId}`);
+    } catch (error) {
+      if (error instanceof BadRequestException) throw error;
+      const typedError = error as Error;
+      this.logger.error(`expireAccount failed: ${typedError.message}`, typedError.stack);
+      throw new InternalServerErrorException(
+        `Failed to expire account: ${typedError.message}`,
+      );
+    }
+  }
+
   private getNetworkPassphrase(): string {
     return this.network === 'mainnet'
       ? StellarSdk.Networks.PUBLIC
       : StellarSdk.Networks.TESTNET;
+  }
+
+  /**
+   * Parses the Soroban ScVal map returned by get_info() into a typed AccountInfo.
+   */
+  private parseAccountInfo(scVal: xdr.ScVal): AccountInfo {
+    const map = scVal.map();
+    if (!map) {
+      throw new Error('Expected ScVal map from get_info()');
+    }
+
+    const get = (key: string): xdr.ScVal => {
+      const entry = map.find((e) => e.key().sym() === key);
+      if (!entry) throw new Error(`Missing field "${key}" in AccountInfo`);
+      return entry.val();
+    };
+
+    const statusSymbol = get('status').vec()?.[0]?.sym() ?? get('status').sym();
+
+    const paymentsVec = get('payments').vec() ?? [];
+    const payments = paymentsVec.map((p) => {
+      const pm = p.map()!;
+      const pGet = (k: string) => pm.find((e) => e.key().sym() === k)!.val();
+      return {
+        asset: pGet('asset').str() as string,
+        amount: pGet('amount').str() as string,
+        timestamp: Number(pGet('timestamp').u64()),
+      };
+    });
+
+    const sweptToEntry = map.find((e) => e.key().sym() === 'swept_to');
+    let sweptTo: string | null = null;
+    if (sweptToEntry) {
+      const val = sweptToEntry.val();
+      // Option<Address> — if it's a vec with one element it's Some(addr)
+      const vec = val.vec();
+      if (vec && vec.length > 0) {
+        sweptTo = StellarSdk.Address.fromScVal(vec[0]).toString();
+      }
+    }
+
+    return {
+      creator: StellarSdk.Address.fromScVal(get('creator')).toString(),
+      status: statusSymbol as AccountInfo['status'],
+      expiryLedger: get('expiry_ledger').u32(),
+      recoveryAddress: StellarSdk.Address.fromScVal(get('recovery_address')).toString(),
+      paymentReceived: get('payment_received').b(),
+      paymentCount: get('payment_count').u32(),
+      payments,
+      sweptTo,
+    };
   }
 }


### PR DESCRIPTION
## Summary

Implements two foundational methods in `StellarService` to close issues #79 and #80.

---

### getAccountInfo(contractId) — Issue #80

- Calls `get_info()` on the EphemeralAccount contract using `simulateTransaction` (read-only, no signing or fees)
- Returns a typed `AccountInfo` interface mirroring the Rust `AccountInfo` struct from `bridgelet-core`
- Throws `BadRequestException` if the contract is not initialized
- Throws `InternalServerErrorException` on RPC failures
- Fully unit-testable without a deployed contract via mocked Soroban RPC responses

### expireAccount(contractId) — Issue #79

- Calls `getAccountInfo()` first to read `expiry_ledger` before invoking `expire()`
- Checks current ledger via `getLatestLedger()` — returns early (non-fatal) if account is not yet expired (scheduling race condition)
- Handles `Error::NotExpired` from the contract as a non-fatal race condition
- Handles `Error::InvalidStatus` as terminal — throws `BadRequestException` with a clear message
- Docblock notes that fund recovery depends on the token transfer stub in `bridgelet-core`

### Tests

11 new unit tests in `stellar.service.spec.ts` covering both methods, all passing.