### PR TITLE
feat: read on-chain EphemeralAccount state via get_info()

### DIFF
--- a/src/modules/stellar/stellar.service.ts
+++ b/src/modules/stellar/stellar.service.ts
@@ -159,6 +159,73 @@ export class StellarService {
   }
 
   /**
+   * Calls EphemeralAccount.get_info() and returns the full on-chain account state.
+   * Used by the sweep and claims modules to verify account readiness before acting,
+   * and internally by expireAccount() to check expiry ledger before submitting.
+   */
+  async getAccountInfo(contractId: string): Promise<{
+    status: string;
+    expiry_ledger: number;
+    payment_received: boolean;
+    payment_count: number;
+    recovery_address: string;
+  }> {
+    const contract = new StellarSdk.Contract(contractId);
+
+    // get_info is a read-only call — use simulateTransaction, no signing needed
+    const dummyKeypair = StellarSdk.Keypair.random();
+    const sourceAccount = new StellarSdk.Account(dummyKeypair.publicKey(), '0');
+
+    const transaction = new StellarSdk.TransactionBuilder(sourceAccount, {
+      fee: StellarSdk.BASE_FEE,
+      networkPassphrase: this.getNetworkPassphrase(),
+    })
+      .addOperation(contract.call('get_info'))
+      .setTimeout(30)
+      .build();
+
+    const simResult = await this.sorobanServer.simulateTransaction(transaction);
+
+    if (SorobanRpc.Api.isSimulationError(simResult)) {
+      throw new Error(`get_info simulation failed: ${simResult.error}`);
+    }
+
+    // Parse the returned ScVal - shape mirrors AccountInfo struct in bridgelet-core
+    const returnVal = simResult.result?.retval;
+    if (!returnVal)
+      throw new Error(`get_info returned no value for ${contractId}`);
+
+    const mapEntries = returnVal.map();
+    if (!mapEntries) {
+      throw new Error(
+        `get_info returned unexpected ScVal type for ${contractId}`,
+      );
+    }
+
+    const fields = mapEntries.map((entry) => ({
+      key: entry.key().sym().toString(),
+      val: entry.val(),
+    }));
+
+    const get = (key: string) => fields.find((f) => f.key === key)?.val;
+
+    const recoveryVal = get('recovery_address');
+    if (!recoveryVal) {
+      throw new Error(
+        `get_info missing recovery_address field for ${contractId}`,
+      );
+    }
+
+    return {
+      status: get('status')?.u32()?.toString() ?? 'unknown',
+      expiry_ledger: get('expiry_ledger')?.u32() ?? 0,
+      payment_received: get('payment_received')?.b() ?? false,
+      payment_count: get('payment_count')?.u32() ?? 0,
+      recovery_address: StellarSdk.Address.fromScVal(recoveryVal).toString(),
+    };
+  }
+
+  /**
    * Polls Soroban RPC until a transaction is confirmed or fails.
    * Used after sendTransaction() which is async by nature.
    */


### PR DESCRIPTION
Closes #80

## What
- Implements `getAccountInfo(contractId)` in `StellarService`
- Uses `simulateTransaction` - no signing or fees required (read-only)
- Returns a typed object mirroring the `AccountInfo` struct from bridgelet-core
- Removes the stub declaration and TODO comment added in #109 placeholder

## Return shape
```typescript
{
  status: string;
  expiry_ledger: number;
  payment_received: boolean;
  payment_count: number;
  recovery_address: string;
}
```

## Notes
- `expireAccount()` now uses the real implementation to guard premature calls
- `payments` and `swept_to` fields from the full `AccountInfo` struct are not yet
  returned - can be added when the claims module needs them
- Uses a random throwaway keypair as the source account since no auth is needed
  for read-only simulation