### PR TITLE
feat: payment detection via Horizon SSE stream (Option A)

### DIFF
--- a/src/modules/accounts/accounts.module.ts
+++ b/src/modules/accounts/accounts.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { Module, OnApplicationBootstrap } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { AccountsController } from './accounts.controller.js';
 import { AccountsService } from './accounts.service.js';
@@ -6,6 +6,7 @@ import { Account } from './entities/account.entity.js';
 import { StellarModule } from '../stellar/stellar.module.js';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { JwtModule } from '@nestjs/jwt';
+import { PaymentMonitorProvider } from '../stellar/providers/payment-monitor-provider.js';
 
 @Module({
   imports: [
@@ -23,7 +24,20 @@ import { JwtModule } from '@nestjs/jwt';
     StellarModule,
   ],
   controllers: [AccountsController],
-  providers: [AccountsService],
+  providers: [AccountsService, PaymentMonitorProvider],
   exports: [AccountsService],
 })
-export class AccountsModule {}
+
+// Note: seeing as PaymentMonitorPRovider is a sub provider in stellar service, this should be adjusted to fit that. Probably call stellatService.PaymentMonitorProvider in the constructor after wiring it up
+export class AccountsModule implements OnApplicationBootstrap {
+  constructor(private readonly paymentMonitor: PaymentMonitorProvider) {}
+
+  /**
+   * After all modules are initialized, restore payment monitoring for any
+   * accounts that were in PENDING_PAYMENT status before the last restart.
+   * This prevents orphaned accounts after a service restart.
+   */
+  async onApplicationBootstrap(): Promise<void> {
+    await this.paymentMonitor.restoreActiveStreams();
+  }
+}

--- a/src/modules/accounts/accounts.service.ts
+++ b/src/modules/accounts/accounts.service.ts
@@ -8,6 +8,7 @@ import { StellarService } from '../stellar/stellar.service.js';
 import { JwtService } from '@nestjs/jwt';
 import * as crypto from 'crypto';
 import { ConfigService } from '@nestjs/config';
+import { PaymentMonitorProvider } from '../stellar/providers/payment-monitor-provider.js';
 
 /**
  * AccountsService — Service-Level Documentation & Contributor Guidance
@@ -93,6 +94,7 @@ export class AccountsService {
     private configService: ConfigService,
     private jwtService: JwtService,
     private stellarService: StellarService,
+    private paymentMonitor: PaymentMonitorProvider,
   ) {}
 
   public async create(
@@ -139,6 +141,11 @@ export class AccountsService {
     });
 
     await this.accountsRepository.save(account);
+
+    // Start monitoring for inbound payment on this account's Stellar address.
+    // PaymentMonitorService will call recordPayment() and update status to
+    // PENDING_CLAIM automatically when funds arrive.
+    this.paymentMonitor.watch(account);
 
     // Return response
     return {

--- a/src/modules/stellar/providers/payment-monitor-provider.spec.ts
+++ b/src/modules/stellar/providers/payment-monitor-provider.spec.ts
@@ -1,0 +1,353 @@
+import { jest } from '@jest/globals';
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { ConfigService } from '@nestjs/config';
+import {
+  Account,
+  AccountStatus,
+} from '../../../modules/accounts/entities/account.entity.js';
+import { PaymentMonitorProvider } from './payment-monitor-provider.js';
+import { StellarService } from '../stellar.service.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const makeAccount = (overrides: Partial<Account> = {}): Account =>
+  ({
+    id: 'acc-uuid-1',
+    publicKey: 'GPUBKEY1234',
+    status: AccountStatus.PENDING_PAYMENT,
+    secretKeyEncrypted: 'enc',
+    fundingSource: 'GFUNDING',
+    amount: '100',
+    asset: 'USDC',
+    claimTokenHash: null,
+    destinationAddress: null,
+    expiresAt: new Date(Date.now() + 86400_000),
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    claimedAt: null,
+    expiredAt: null,
+    metadata: null,
+    ...overrides,
+  }) as Account;
+
+const makePaymentRecord = (overrides: Partial<any> = {}) => ({
+  type: 'payment',
+  to: 'GPUBKEY1234',
+  from: 'GSENDER',
+  amount: '100.0000000',
+  asset_type: 'credit_alphanum4',
+  asset_code: 'USDC',
+  asset_issuer: 'GDEST47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA',
+  ...overrides,
+});
+
+// ---------------------------------------------------------------------------
+// Mock Horizon server
+// ---------------------------------------------------------------------------
+
+// Capture the callbacks so tests can invoke them manually
+let capturedOnMessage: ((r: any) => void) | null = null;
+let capturedOnError: ((e: any) => void) | null = null;
+const mockCloseStream = jest.fn();
+
+const mockStreamFn = jest.fn(({ onmessage, onerror }) => {
+  capturedOnMessage = onmessage;
+  capturedOnError = onerror;
+  return mockCloseStream;
+});
+
+const mockPaymentsBuilder = {
+  forAccount: jest.fn().mockReturnThis(),
+  cursor: jest.fn().mockReturnThis(),
+  stream: mockStreamFn,
+};
+
+jest.mock('@stellar/stellar-sdk', () => {
+  const actual = jest.requireActual<typeof import('@stellar/stellar-sdk')>(
+    '@stellar/stellar-sdk',
+  );
+  return {
+    ...actual,
+    Horizon: {
+      ...actual.Horizon,
+      Server: jest.fn().mockImplementation(() => ({
+        payments: () => mockPaymentsBuilder,
+      })),
+    },
+    Asset: actual.Asset,
+    Networks: actual.Networks,
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('PaymentMonitorProvider', () => {
+  let service: PaymentMonitorProvider;
+  let stellarService: {
+    recordPayment: jest.MockedFunction<StellarService['recordPayment']>;
+  };
+  let accountsRepo: {
+    update: jest.MockedFunction<() => Promise<void>>;
+    find: jest.MockedFunction<() => Promise<Account[]>>;
+  };
+
+  beforeEach(async () => {
+    capturedOnMessage = null;
+    capturedOnError = null;
+    mockCloseStream.mockReset();
+    mockStreamFn.mockClear();
+    mockPaymentsBuilder.forAccount.mockClear();
+    mockPaymentsBuilder.cursor.mockClear();
+
+    accountsRepo = {
+      update: jest.fn<() => Promise<void>>().mockResolvedValue(undefined),
+      find: jest.fn<() => Promise<Account[]>>().mockResolvedValue([]),
+    };
+
+    const stellarMock = {
+      recordPayment: jest
+        .fn<StellarService['recordPayment']>()
+        .mockResolvedValue(undefined),
+    };
+
+    const configMock = {
+      getOrThrow: jest.fn((key: string) => {
+        const map: Record<string, string> = {
+          'stellar.horizonUrl': 'https://horizon-testnet.stellar.org',
+          'stellar.ephemeralContractId': 'CONTRACT123',
+          'stellar.fundingSecret': 'SFUNDING_SECRET',
+          'stellar.network': 'testnet',
+        };
+        return map[key];
+      }),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        PaymentMonitorProvider,
+        { provide: getRepositoryToken(Account), useValue: accountsRepo },
+        { provide: StellarService, useValue: stellarMock },
+        { provide: ConfigService, useValue: configMock },
+      ],
+    }).compile();
+
+    service = module.get(PaymentMonitorProvider);
+
+    // bypass real Asset validation - we're not testing address resolution here
+    jest
+      .spyOn(service as any, 'resolveAssetAddress')
+      .mockReturnValue('MOCK_ASSET_CONTRACT_ADDRESS');
+
+    stellarService = module.get(StellarService);
+  });
+
+  // -------------------------------------------------------------------------
+  // watch() / unwatch()
+  // -------------------------------------------------------------------------
+
+  describe('watch()', () => {
+    it('opens a Horizon payment stream for the account', () => {
+      service.watch(makeAccount());
+      expect(mockPaymentsBuilder.forAccount).toHaveBeenCalledWith(
+        'GPUBKEY1234',
+      );
+      expect(mockPaymentsBuilder.cursor).toHaveBeenCalledWith('now');
+      expect(mockStreamFn).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not open a second stream if already watching', () => {
+      const acc = makeAccount();
+      service.watch(acc);
+      service.watch(acc);
+      expect(mockStreamFn).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('unwatch()', () => {
+    it('calls the close handle and removes the account from tracking', () => {
+      service.watch(makeAccount());
+      service.unwatch('acc-uuid-1');
+      expect(mockCloseStream).toHaveBeenCalledTimes(1);
+      // Watching again should open a new stream (not a no-op)
+      service.watch(makeAccount());
+      expect(mockStreamFn).toHaveBeenCalledTimes(2);
+    });
+
+    it('is safe to call for an account that is not being watched', () => {
+      expect(() => service.unwatch('not-watched')).not.toThrow();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Payment event handling
+  // -------------------------------------------------------------------------
+
+  describe('on inbound payment', () => {
+    beforeEach(() => {
+      service.watch(makeAccount());
+    });
+
+    it('calls recordPayment() with correct params when a valid payment arrives', async () => {
+      capturedOnMessage!(makePaymentRecord());
+      await Promise.resolve(); // flush microtasks
+
+      expect(stellarService.recordPayment).toHaveBeenCalledWith(
+        expect.objectContaining({
+          contractId: 'CONTRACT123',
+          signerSecret: 'SFUNDING_SECRET',
+          amount: expect.any(BigInt),
+        }),
+      );
+    });
+
+    it('updates account status to PENDING_CLAIM after recordPayment() succeeds', async () => {
+      capturedOnMessage!(makePaymentRecord());
+      await new Promise(setImmediate); // flush async chain
+
+      expect(accountsRepo.update).toHaveBeenCalledWith('acc-uuid-1', {
+        status: AccountStatus.PENDING_CLAIM,
+      });
+    });
+
+    it('closes the stream after a successful payment is recorded', async () => {
+      capturedOnMessage!(makePaymentRecord());
+      await new Promise(setImmediate);
+
+      expect(mockCloseStream).toHaveBeenCalledTimes(1);
+    });
+
+    it('ignores events that are not type "payment"', async () => {
+      capturedOnMessage!({ ...makePaymentRecord(), type: 'create_account' });
+      await new Promise(setImmediate);
+
+      expect(stellarService.recordPayment).not.toHaveBeenCalled();
+    });
+
+    it('ignores payments not addressed to this account', async () => {
+      capturedOnMessage!({ ...makePaymentRecord(), to: 'GOTHER' });
+      await new Promise(setImmediate);
+
+      expect(stellarService.recordPayment).not.toHaveBeenCalled();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Idempotency — DuplicateAsset
+  // -------------------------------------------------------------------------
+
+  describe('idempotency', () => {
+    it('treats DuplicateAsset errors as no-ops and leaves stream open', async () => {
+      stellarService.recordPayment.mockRejectedValueOnce(
+        new Error('DuplicateAsset'),
+      );
+      service.watch(makeAccount());
+      capturedOnMessage!(makePaymentRecord());
+      await new Promise(setImmediate);
+
+      expect(accountsRepo.update).not.toHaveBeenCalled();
+      expect(mockCloseStream).not.toHaveBeenCalled();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Non-retryable contract errors
+  // -------------------------------------------------------------------------
+
+  describe('non-retryable contract errors', () => {
+    it.each(['TooManyPayments', 'InvalidAmount'])(
+      'marks account as FAILED and stops the stream on %s',
+      async (errMsg) => {
+        stellarService.recordPayment.mockRejectedValueOnce(new Error(errMsg));
+        service.watch(makeAccount());
+        capturedOnMessage!(makePaymentRecord());
+        await new Promise(setImmediate);
+
+        expect(accountsRepo.update).toHaveBeenCalledWith('acc-uuid-1', {
+          status: AccountStatus.FAILED,
+        });
+        expect(mockCloseStream).toHaveBeenCalledTimes(1);
+      },
+    );
+  });
+
+  // -------------------------------------------------------------------------
+  // Stream error handler
+  // -------------------------------------------------------------------------
+
+  describe('stream onerror', () => {
+    it('logs the error without closing the stream (Horizon reconnects)', () => {
+      service.watch(makeAccount());
+      // Should not throw
+      expect(() => capturedOnError!(new Error('network blip'))).not.toThrow();
+      // Stream is still tracked
+      expect(mockCloseStream).not.toHaveBeenCalled();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Restart recovery
+  // -------------------------------------------------------------------------
+
+  describe('restoreActiveStreams()', () => {
+    it('opens streams for all PENDING_PAYMENT accounts found in DB', async () => {
+      accountsRepo.find.mockResolvedValueOnce([
+        makeAccount({ id: 'a1', publicKey: 'GPK1' }),
+        makeAccount({ id: 'a2', publicKey: 'GPK2' }),
+      ]);
+
+      await service.restoreActiveStreams();
+
+      expect(mockStreamFn).toHaveBeenCalledTimes(2);
+    });
+
+    it('does nothing when there are no active accounts', async () => {
+      accountsRepo.find.mockResolvedValueOnce([]);
+      await service.restoreActiveStreams();
+      expect(mockStreamFn).not.toHaveBeenCalled();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Shutdown
+  // -------------------------------------------------------------------------
+
+  describe('onModuleDestroy()', () => {
+    it('closes all open streams', () => {
+      service.watch(makeAccount({ id: 'a1', publicKey: 'GPK1' }));
+      service.watch(makeAccount({ id: 'a2', publicKey: 'GPK2' }));
+      service.onModuleDestroy();
+      expect(mockCloseStream).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Amount conversion
+  // -------------------------------------------------------------------------
+
+  describe('parseAmountToStroops (via integration)', () => {
+    it('converts "100.0000000" to 1_000_000_000n stroops', async () => {
+      service.watch(makeAccount());
+      capturedOnMessage!(makePaymentRecord({ amount: '100.0000000' }));
+      await new Promise(setImmediate);
+
+      expect(stellarService.recordPayment).toHaveBeenCalledWith(
+        expect.objectContaining({ amount: 1_000_000_000n }),
+      );
+    });
+
+    it('converts "1.5000000" to 15_000_000n stroops', async () => {
+      service.watch(makeAccount());
+      capturedOnMessage!(makePaymentRecord({ amount: '1.5000000' }));
+      await new Promise(setImmediate);
+
+      expect(stellarService.recordPayment).toHaveBeenCalledWith(
+        expect.objectContaining({ amount: 15_000_000n }),
+      );
+    });
+  });
+});

--- a/src/modules/stellar/providers/payment-monitor-provider.ts
+++ b/src/modules/stellar/providers/payment-monitor-provider.ts
@@ -1,0 +1,276 @@
+import { Injectable, Logger, OnModuleDestroy } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { ConfigService } from '@nestjs/config';
+import * as StellarSdk from '@stellar/stellar-sdk';
+import { StellarService } from '../stellar.service.js';
+import {
+  Account,
+  AccountStatus,
+} from '../../../modules/accounts/entities/account.entity.js';
+
+/**
+ * PaymentMonitorProvider - Horizon SSE-based payment detection
+ *
+ * Watches active ephemeral accounts for inbound Stellar payments using
+ * Horizon's server-sent event stream. When a payment is detected it:
+ *   1. Calls StellarService.recordPayment() to register it on the contract
+ *   2. Updates the account status to PENDING_CLAIM in the database
+ *
+ * Lifecycle:
+ *   - watch(account)       called by AccountsService immediately after creation
+ *   - unwatch(accountId)   called internally when a terminal state is reached
+ *   - onModuleDestroy()    closes all open streams on shutdown
+ *
+ * Idempotency:
+ *   DuplicateAsset errors from the contract are treated as no-ops - the stream
+ *   may emit duplicate events and that is handled here, not in StellarService.
+ */
+
+@Injectable()
+export class PaymentMonitorProvider implements OnModuleDestroy {
+  private readonly logger = new Logger(PaymentMonitorProvider.name);
+
+  /** accountId → active EventSource close handle */
+  private readonly streams = new Map<string, () => void>();
+
+  private horizonServer: StellarSdk.Horizon.Server;
+
+  constructor(
+    @InjectRepository(Account)
+    private readonly accountsRepository: Repository<Account>,
+    private readonly stellarService: StellarService,
+    private readonly configService: ConfigService,
+  ) {
+    const horizonUrl =
+      this.configService.getOrThrow<string>('stellar.horizonUrl');
+    this.horizonServer = new StellarSdk.Horizon.Server(horizonUrl);
+  }
+
+  /**
+   * Opens a Horizon payment SSE stream for the given account.
+   * Safe to call multiple times for the same account — subsequent calls are
+   * ignored if a stream is already active.
+   */
+  watch(account: Account): void {
+    if (this.streams.has(account.id)) {
+      this.logger.debug(
+        `Already watching account ${account.id} (${account.publicKey})`,
+      );
+      return;
+    }
+
+    this.logger.log(
+      `Starting payment stream for account ${account.id} (${account.publicKey})`,
+    );
+
+    const closeStream = this.horizonServer
+      .payments()
+      .forAccount(account.publicKey)
+      .cursor('now') // only react to new payments, not historical ones
+      .stream({
+        onmessage: (record) => {
+          if ((record.type as string) !== 'payment') return;
+          void this.handlePaymentEvent(
+            account,
+            record as StellarSdk.Horizon.ServerApi.PaymentOperationRecord,
+          );
+        },
+        onerror: (err) => {
+          const errMsg =
+            err instanceof Error ? err.message : JSON.stringify(err);
+          this.logger.error(
+            `Stream error for account ${account.id}: ${errMsg}`,
+          );
+        },
+      });
+
+    this.streams.set(account.id, closeStream);
+  }
+
+  /**
+   * Stops watching an account and closes its SSE stream.
+   * Called automatically when a terminal status is reached.
+   */
+  unwatch(accountId: string): void {
+    const close = this.streams.get(accountId);
+    if (!close) return;
+
+    close();
+    this.streams.delete(accountId);
+    this.logger.log(`Stopped payment stream for account ${accountId}`);
+  }
+
+  /** Close all open streams gracefully on app shutdown. */
+  onModuleDestroy(): void {
+    this.logger.log(
+      `Closing ${this.streams.size} active payment stream(s) on shutdown`,
+    );
+    for (const [id, close] of this.streams) {
+      close();
+      this.logger.debug(`Closed stream for account ${id}`);
+    }
+    this.streams.clear();
+  }
+
+  /**
+   * Restores monitoring for all accounts that are still in PENDING_PAYMENT
+   * status at startup. This ensures that accounts created before a restart
+   * are not silently orphaned.
+   *
+   * Should be called once from AccountsModule's onApplicationBootstrap hook.
+   */
+  async restoreActiveStreams(): Promise<void> {
+    const active = await this.accountsRepository.find({
+      where: { status: AccountStatus.PENDING_PAYMENT },
+    });
+
+    if (active.length === 0) {
+      this.logger.log('No active accounts to restore monitoring for');
+      return;
+    }
+
+    this.logger.log(
+      `Restoring payment monitoring for ${active.length} account(s)`,
+    );
+    for (const account of active) {
+      this.watch(account);
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private
+  // ---------------------------------------------------------------------------
+
+  private async handlePaymentEvent(
+    account: Account,
+    record: StellarSdk.Horizon.ServerApi.PaymentOperationRecord,
+  ): Promise<void> {
+    // Only handle inbound payments to this account's address
+    if (record.to !== account.publicKey) return;
+
+    this.logger.log(
+      `Inbound payment detected for account ${account.id}: ` +
+        `${record.amount} ${record.asset_code ?? 'XLM'} from ${record.from}`,
+    );
+
+    const contractId = this.configService.getOrThrow<string>(
+      'stellar.ephemeralContractId',
+    );
+    const signerSecret = this.configService.getOrThrow<string>(
+      'stellar.fundingSecret',
+    );
+
+    // Derive asset contract address from the Horizon payment record.
+    // XLM (native) is represented as the zero contract address on Soroban.
+    const assetAddress = this.resolveAssetAddress(record);
+
+    // Convert the decimal amount string from Horizon to i128 bigint (stroops).
+    // Stellar amounts have 7 decimal places: 1 XLM = 10_000_000 stroops.
+    const amountBigint = this.parseAmountToStroops(record.amount);
+
+    try {
+      await this.stellarService.recordPayment({
+        contractId,
+        amount: amountBigint,
+        assetAddress,
+        signerSecret,
+      });
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+
+      // DuplicateAsset means the contract already has this payment recorded.
+      // This can happen if the stream emits a duplicate event — treat as no-op.
+      if (msg.includes('DuplicateAsset')) {
+        this.logger.warn(
+          `Duplicate payment event ignored for account ${account.id} ` +
+            `(asset already recorded on contract)`,
+        );
+        return;
+      }
+
+      // TooManyPayments and InvalidAmount are non-retryable contract errors.
+      // Log and stop watching — the account is in a bad state.
+      if (msg.includes('TooManyPayments') || msg.includes('InvalidAmount')) {
+        this.logger.error(
+          `Non-retryable contract error for account ${account.id}: ${msg}. ` +
+            `Stopping monitor.`,
+        );
+        this.unwatch(account.id);
+        await this.markAccountFailed(account.id);
+        return;
+      }
+
+      // Transient/unknown errors — log but leave the stream open so it retries
+      // on the next payment event or on the next duplicate event from Horizon.
+      this.logger.error(
+        `recordPayment() failed for account ${account.id}: ${msg}`,
+      );
+      return;
+    }
+
+    // recordPayment() succeeded — update DB status and stop watching
+    await this.markAccountPendingClaim(account.id);
+    this.unwatch(account.id);
+  }
+
+  private async markAccountPendingClaim(accountId: string): Promise<void> {
+    await this.accountsRepository.update(accountId, {
+      status: AccountStatus.PENDING_CLAIM,
+    });
+    this.logger.log(`Account ${accountId} status → PENDING_CLAIM`);
+  }
+
+  private async markAccountFailed(accountId: string): Promise<void> {
+    await this.accountsRepository.update(accountId, {
+      status: AccountStatus.FAILED,
+    });
+    this.logger.warn(`Account ${accountId} status → FAILED`);
+  }
+
+  /**
+   * Converts a Horizon payment record's asset to the Soroban contract address
+   * expected by recordPayment().
+   *
+   * For non-native assets the contract address is the Stellar Asset Contract (SAC)
+   * address, which Stellar derives deterministically from the classic asset.
+   * For native XLM the SAC address is derived from the native asset.
+   */
+  private resolveAssetAddress(
+    record: StellarSdk.Horizon.ServerApi.PaymentOperationRecord,
+  ): string {
+    let asset: StellarSdk.Asset;
+
+    if (record.asset_type === 'native') {
+      asset = StellarSdk.Asset.native();
+    } else {
+      if (!record.asset_code || !record.asset_issuer) {
+        throw new Error(
+          `Payment record missing asset_code or asset_issuer for account ${record.to}`,
+        );
+      }
+      asset = new StellarSdk.Asset(record.asset_code, record.asset_issuer);
+    }
+
+    // contractId() returns the SAC address for a given network passphrase
+    const networkPassphrase =
+      this.configService.getOrThrow<string>('stellar.network') === 'mainnet'
+        ? StellarSdk.Networks.PUBLIC
+        : StellarSdk.Networks.TESTNET;
+
+    return asset.contractId(networkPassphrase);
+  }
+
+  /**
+   * Converts a Horizon decimal amount string (e.g. "100.5000000") to stroops
+   * as a bigint for the i128 contract parameter.
+   * 1 unit = 10_000_000 stroops (7 decimal places).
+   */
+  private parseAmountToStroops(amount: string): bigint {
+    // Split on decimal point
+    const [whole, fraction = ''] = amount.split('.');
+    // Pad or truncate fraction to exactly 7 digits
+    const paddedFraction = fraction.padEnd(7, '0').slice(0, 7);
+    return BigInt(whole) * 10_000_000n + BigInt(paddedFraction);
+  }
+}

--- a/src/modules/stellar/stellar.module.ts
+++ b/src/modules/stellar/stellar.module.ts
@@ -1,8 +1,12 @@
 import { Module } from '@nestjs/common';
 import { StellarService } from './stellar.service.js';
+import { PaymentMonitorProvider } from './providers/payment-monitor-provider.js';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Account } from '../accounts/entities/account.entity.js';
 
 @Module({
-  providers: [StellarService],
-  exports: [StellarService],
+  imports: [TypeOrmModule.forFeature([Account])],
+  providers: [StellarService, PaymentMonitorProvider],
+  exports: [StellarService, PaymentMonitorProvider],
 })
 export class StellarModule {}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "module": "nodenext",
     "moduleResolution": "nodenext",
+    "types": ["node", "jest"],
     "resolvePackageJsonExports": true,
     "esModuleInterop": true,
     "isolatedModules": true,


### PR DESCRIPTION
Closes #81 

## Decision
Option A - Horizon SSE stream per active account. Chosen for MVP because
disbursements are expected in small batches where per-account connections
are acceptable. Option B (polling) or C (webhooks) can replace this later
without changing the recordPayment() contract.

## What
- Adds `PaymentMonitorProvider` to the stellar module
- Opens a Horizon SSE stream per account on `watch(account)`
- On inbound payment: calls `recordPayment()` then marks account `PENDING_CLAIM`
- `unwatch(accountId)` closes the stream when a terminal state is reached
- `onModuleDestroy()` closes all streams gracefully on shutdown
- `restoreActiveStreams()` re-attaches monitors for `PENDING_PAYMENT` accounts on restart

## Idempotency
`DuplicateAsset` contract errors are treated as no-ops - Horizon may emit
duplicate events and that is handled here, not in `StellarService`.

## Notes
`TooManyPayments` and `InvalidAmount` are treated as non-retryable -
the stream is closed and the account is marked `FAILED`.
Transient errors leave the stream open for retry on the next event.