### PR TITLE
fix: flag generateAuthSignature as MVP stub with env guard (#94)

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,14 @@ The following services/imports are currently **commented out** to allow `npm run
      `expiry_ledger` (u32 ledger sequence) required by the contract
    - `expiresAt` Date is currently unused in `StellarService`
    - Conversion formula: `current_ledger + (expiresIn / 5)`
+4. **Sweep Authorization Signature** (`src/modules/sweeps/providers/contract.provider.ts`)
+   - **Current:** `generateAuthSignature()` produces a fake 64-byte stub signature
+   - **Works because:** `EphemeralAccount.verify_sweep_authorization()` in `bridgelet-core`
+     is also a stub that accepts any signature (documented in bridgelet-core README)
+   - **Impact:** Sweep authorization is not cryptographically enforced in development
+   - **Guard:** Method throws if called outside `development` or `test` environments
+   - **Required:** Real Ed25519 signing against the `SweepController`'s `authorized_signer`
+     once `bridgelet-core` implements real verification.
 
 ### Status:
 

--- a/src/modules/sweeps/providers/contract.provider.ts
+++ b/src/modules/sweeps/providers/contract.provider.ts
@@ -123,23 +123,48 @@ export class ContractProvider {
   }
 
   /**
-   * Generate authorization signature for sweep
-   * In production: Sign with authorized private key
-   * For MVP: Generate dummy signature
+   * ⚠️ MVP STUB - NOT FOR PRODUCTION USE
+   *
+   * Generates a fake 64-byte authorization signature for the contract's
+   * sweep() function. This works only because EphemeralAccount.verify_sweep_authorization()
+   * in bridgelet-core is also a stub that accepts any 64-byte value.
+   *
+   * WHAT A REAL IMPLEMENTATION MUST DO:
+   * - The SDK must hold an authorized Ed25519 signing keypair
+   * - The message to sign must be: hash(ephemeralPublicKey + destinationAddress + nonce)
+   * - The nonce must match what the SweepController contract tracks to prevent replays
+   * - The corresponding public key must be registered in the SweepController
+   *   via its initialize() function as the `authorized_signer`
+   *
+   * Once bridgelet-core replaces its stub with real Ed25519 verification,
+   * this method must be replaced before any sweep will succeed on-chain.
+   *
+   * See: bridgelet-core/contracts/ephemeral_account/src/lib.rs verify_sweep_authorization()
+   * See: bridgelet-core/contracts/sweep_controller/src/authorization.rs
    */
   private generateAuthSignature(params: AuthorizeSweepParams): Buffer {
-    // TODO: Implement proper signature generation
-    // Should sign hash of (ephemeralPublicKey + destinationAddress + timestamp)
-    // with SDK's authorized signing key
-
-    // For MVP: Return dummy 64-byte signature
+    const isDevelopmentOrTest = ['development', 'test'].includes(
+      process.env.NODE_ENV ?? '',
+    );
+    if (!isDevelopmentOrTest) {
+      this.logger.error(
+        'CRITICAL: generateAuthSignature() is an MVP stub and must not be called ' +
+          `in environment: ${process.env.NODE_ENV}. ` +
+          'Implement real Ed25519 signing before deploying to staging or production.',
+      );
+      throw new Error(
+        'Sweep authorization stub cannot be used outside development/test environments. ' +
+          'See ContractProvider.generateAuthSignature() for implementation requirements.',
+      );
+    }
+    this.logger.warn(
+      '⚠️ Using MVP stub signature for sweep authorization. ' +
+        'This only works because bridgelet-core verification is also stubbed.',
+    );
     const message = `${params.ephemeralPublicKey}:${params.destinationAddress}`;
     const messageHash = hash(Buffer.from(message));
-
-    // Pad to 64 bytes
     const signature = Buffer.alloc(64);
     messageHash.copy(signature, 0);
-
     return signature;
   }
 


### PR DESCRIPTION
- Add warning docblock explaining what a real Ed25519 implementation must do
- Throw in non-development/test environments to prevent silent stub usage in staging/prod
- Add corresponding note to README known limitations section

closes #94 