### PR TITLE
Fix: Audit and create all database migrations (#103)

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,13 @@ npm install
 cp .env.example .env
 # Edit .env with your configuration
 
-# Run migrations
+# Run database migrations
+# DataSource config : src/config/typeorm.config.ts
+# Migrations        : src/database/migrations/
+#   1718100000000-CreateAccountsTable           (accounts table, status enum, expiredAt, metadata)
+#   1718100001000-CreateClaimsTable              (claims table + FK to accounts)
+#   1718100002000-AddInitializingToAccountStatus (adds INITIALIZING to account_status enum)
+#   1718100003000-CreateWebhooksTable            (webhooks table)
 npm run migration:run
 
 # Start development server

--- a/src/config/typeorm.config.ts
+++ b/src/config/typeorm.config.ts
@@ -1,0 +1,17 @@
+import { DataSource } from 'typeorm';
+import { dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+export default new DataSource({
+  type: 'postgres',
+  host: process.env.DATABASE_HOST || 'localhost',
+  port: parseInt(process.env.DATABASE_PORT ?? '5432', 10),
+  username: process.env.DATABASE_USER || 'bridgelet_user',
+  password: process.env.DATABASE_PASSWORD || 'bridgelet_pass',
+  database: process.env.DATABASE_NAME || 'bridgelet',
+  entities: [__dirname + '/../**/*.entity{.ts,.js}'],
+  migrations: [__dirname + '/../database/migrations/*{.ts,.js}'],
+});

--- a/src/database/migrations/1718100000000-CreateAccountsTable.ts
+++ b/src/database/migrations/1718100000000-CreateAccountsTable.ts
@@ -1,0 +1,59 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CreateAccountsTable1718100000000 implements MigrationInterface {
+  name = 'CreateAccountsTable1718100000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TYPE "public"."account_status_enum" AS ENUM(
+        'pending_payment',
+        'pending_claim',
+        'claimed',
+        'expired',
+        'failed'
+      )
+    `);
+    await queryRunner.query(`
+      CREATE TABLE "accounts" (
+        "id"                  uuid                            NOT NULL DEFAULT gen_random_uuid(),
+        "publicKey"           character varying(56)           NOT NULL,
+        "secretKeyEncrypted"  text                            NOT NULL,
+        "fundingSource"       character varying(56)           NOT NULL,
+        "amount"              numeric(18,7)                   NOT NULL,
+        "asset"               character varying(100)          NOT NULL,
+        "status"              "public"."account_status_enum"  NOT NULL DEFAULT 'pending_payment',
+        "claimTokenHash"      character varying(64),
+        "destinationAddress"  character varying(56),
+        "expiresAt"           TIMESTAMP                       NOT NULL,
+        "createdAt"           TIMESTAMP                       NOT NULL DEFAULT now(),
+        "updatedAt"           TIMESTAMP                       NOT NULL DEFAULT now(),
+        "claimedAt"           TIMESTAMP,
+        "expiredAt"           TIMESTAMP,
+        "metadata"            jsonb,
+        CONSTRAINT "UQ_accounts_publicKey" UNIQUE ("publicKey"),
+        CONSTRAINT "PK_accounts" PRIMARY KEY ("id")
+      )
+    `);
+    await queryRunner.query(
+      `CREATE INDEX "IDX_accounts_publicKey"      ON "accounts" ("publicKey")`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_accounts_status"         ON "accounts" ("status")`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_accounts_claimTokenHash" ON "accounts" ("claimTokenHash")`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_accounts_expiresAt"      ON "accounts" ("expiresAt")`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX "IDX_accounts_expiresAt"`);
+    await queryRunner.query(`DROP INDEX "IDX_accounts_claimTokenHash"`);
+    await queryRunner.query(`DROP INDEX "IDX_accounts_status"`);
+    await queryRunner.query(`DROP INDEX "IDX_accounts_publicKey"`);
+    await queryRunner.query(`DROP TABLE "accounts"`);
+    await queryRunner.query(`DROP TYPE "public"."account_status_enum"`);
+  }
+}

--- a/src/database/migrations/1718100001000-CreateClaimsTable.ts
+++ b/src/database/migrations/1718100001000-CreateClaimsTable.ts
@@ -1,0 +1,34 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CreateClaimsTable1718100001000 implements MigrationInterface {
+  name = 'CreateClaimsTable1718100001000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE "claims" (
+        "id"                 uuid                   NOT NULL DEFAULT gen_random_uuid(),
+        "accountId"          uuid                   NOT NULL,
+        "destinationAddress" character varying(56)  NOT NULL,
+        "sweepTxHash"        character varying(64)  NOT NULL,
+        "amountSwept"        character varying(100) NOT NULL,
+        "asset"              character varying(100) NOT NULL,
+        "claimedAt"          TIMESTAMP              NOT NULL,
+        "createdAt"          TIMESTAMP              NOT NULL DEFAULT now(),
+        "updatedAt"          TIMESTAMP              NOT NULL DEFAULT now(),
+        CONSTRAINT "PK_claims" PRIMARY KEY ("id"),
+        CONSTRAINT "FK_claims_accountId"
+          FOREIGN KEY ("accountId")
+          REFERENCES "accounts"("id")
+          ON DELETE CASCADE
+      )
+    `);
+    await queryRunner.query(
+      `CREATE INDEX "IDX_claims_accountId" ON "claims" ("accountId")`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX "IDX_claims_accountId"`);
+    await queryRunner.query(`DROP TABLE "claims"`);
+  }
+}

--- a/src/database/migrations/1718100002000-AddInitializingToAccountStatus.ts
+++ b/src/database/migrations/1718100002000-AddInitializingToAccountStatus.ts
@@ -1,0 +1,48 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddInitializingToAccountStatus1718100002000 implements MigrationInterface {
+  name = 'AddInitializingToAccountStatus1718100002000';
+
+  // ALTER TYPE ADD VALUE cannot run inside a transaction on some PostgreSQL
+  // versions -- setting transaction = false keeps this migration safe.
+  public transaction = false;
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TYPE "public"."account_status_enum"
+        ADD VALUE 'initializing' BEFORE 'pending_payment'
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    // PostgreSQL has no DROP VALUE -- must recreate the enum type.
+    await queryRunner.query(
+      `ALTER TABLE "accounts" ALTER COLUMN "status" DROP DEFAULT`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "accounts" ALTER COLUMN "status" TYPE text USING "status"::text`,
+    );
+    await queryRunner.query(`DROP TYPE "public"."account_status_enum"`);
+    await queryRunner.query(`
+      CREATE TYPE "public"."account_status_enum" AS ENUM(
+        'pending_payment',
+        'pending_claim',
+        'claimed',
+        'expired',
+        'failed'
+      )
+    `);
+    // Remap any rows that were in INITIALIZING back to PENDING_PAYMENT.
+    await queryRunner.query(
+      `UPDATE "accounts" SET "status" = 'pending_payment' WHERE "status" = 'initializing'`,
+    );
+    await queryRunner.query(`
+      ALTER TABLE "accounts"
+        ALTER COLUMN "status" TYPE "public"."account_status_enum"
+        USING "status"::"public"."account_status_enum"
+    `);
+    await queryRunner.query(
+      `ALTER TABLE "accounts" ALTER COLUMN "status" SET DEFAULT 'pending_payment'`,
+    );
+  }
+}

--- a/src/database/migrations/1718100003000-CreateWebhooksTable.ts
+++ b/src/database/migrations/1718100003000-CreateWebhooksTable.ts
@@ -1,0 +1,30 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CreateWebhooksTable1718100003000 implements MigrationInterface {
+  name = 'CreateWebhooksTable1718100003000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE "webhooks" (
+        "id"               uuid                    NOT NULL DEFAULT gen_random_uuid(),
+        "url"              character varying(2048)  NOT NULL,
+        "secret"           character varying(256),
+        "events"           jsonb                   NOT NULL DEFAULT '[]',
+        "isActive"         boolean                 NOT NULL DEFAULT true,
+        "description"      character varying(255),
+        "lastTriggeredAt"  TIMESTAMP,
+        "createdAt"        TIMESTAMP               NOT NULL DEFAULT now(),
+        "updatedAt"        TIMESTAMP               NOT NULL DEFAULT now(),
+        CONSTRAINT "PK_webhooks" PRIMARY KEY ("id")
+      )
+    `);
+    await queryRunner.query(
+      `CREATE INDEX "IDX_webhooks_isActive" ON "webhooks" ("isActive")`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX "IDX_webhooks_isActive"`);
+    await queryRunner.query(`DROP TABLE "webhooks"`);
+  }
+}


### PR DESCRIPTION
- Add src/config/typeorm.config.ts (DataSource for TypeORM CLI, was missing)
- Add migration 1718100000000: CreateAccountsTable
    accounts table with status enum, expiredAt, metadata, all indexes
- Add migration 1718100001000: CreateClaimsTable
    claims table with FK + CASCADE to accounts
- Add migration 1718100002000: AddInitializingToAccountStatus
    ALTER TYPE ADD VALUE with safe down that recreates the enum
- Add migration 1718100003000: CreateWebhooksTable
    webhooks table for Issue 102
- Update README installation section with migration inventory
- All migrations have both up and down methods

NOTE: migrations were hand-written from entity definitions (no live DB was
available to run migration:generate). To regenerate a diff against a live DB:

  npm run typeorm -- migration:generate -d src/config/typeorm.config.ts src/database/migrations/MigrationName

The migration:generate script in package.json is also missing the -d flag
and will need to be fixed before auto-generation works.

closes #103 