### PR TITLE
feat: Consolidate secret encryption into a shared utility

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,3 +40,6 @@ WEBHOOK_TIMEOUT=5000
 
 # Logging
 LOG_LEVEL=debug
+# 32-byte AES-256-GCM encryption key for ephemeral secret storage
+# Generate with: node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
+ENCRYPTION_KEY=your-64-character-hex-string-here

--- a/package-lock.json
+++ b/package-lock.json
@@ -237,7 +237,6 @@
       "integrity": "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
         "@babel/generator": "^7.28.6",
@@ -748,7 +747,7 @@
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
       "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/trace-mapping": "0.3.9"
@@ -761,7 +760,7 @@
       "version": "0.3.9",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
       "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
@@ -2023,7 +2022,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -2044,7 +2043,7 @@
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
@@ -2136,7 +2135,6 @@
       "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-11.1.12.tgz",
       "integrity": "sha512-v6U3O01YohHO+IE3EIFXuRuu3VJILWzyMmSYZXpyBbnp0hk0mFyHxK2w3dF4I5WnbwiRbWlEXdeXFvPQ7qaZzw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "file-type": "21.3.0",
         "iterare": "1.2.1",
@@ -2184,7 +2182,6 @@
       "integrity": "sha512-97DzTYMf5RtGAVvX1cjwpKRiCUpkeQ9CCzSAenqkAhOmNVVFaApbhuw+xrDt13rsCa2hHVOYPrV4dBgOYMJjsA==",
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@nuxt/opencollective": "0.4.1",
         "fast-safe-stringify": "2.1.1",
@@ -2258,7 +2255,6 @@
       "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-11.1.12.tgz",
       "integrity": "sha512-GYK/vHI0SGz5m8mxr7v3Urx8b9t78Cf/dj5aJMZlGd9/1D9OI1hAl00BaphjEXINUJ/BQLxIlF2zUjrYsd6enQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cors": "2.8.5",
         "express": "5.2.1",
@@ -2704,28 +2700,28 @@
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.12.tgz",
       "integrity": "sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@tsconfig/node12": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
       "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@tsconfig/node14": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
       "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@tsconfig/node16": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
       "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@tybys/wasm-util": {
@@ -2828,7 +2824,6 @@
       "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "*",
         "@types/json-schema": "*"
@@ -2963,7 +2958,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.7.tgz",
       "integrity": "sha512-MciR4AKGHWl7xwxkBa6xUGxQJ4VBOmPTF7sL+iGzuahOFaO0jHCsuEfS80pan1ef4gWId1oWOweIhrDEYLuaOw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -3109,7 +3103,6 @@
       "integrity": "sha512-nm3cvFN9SqZGXjmw5bZ6cGmvJSyJPn0wU9gHAZZHDnZl2wF9PhHv78Xf06E0MaNk4zLVHL8hb2/c32XvyJOLQg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.53.1",
         "@typescript-eslint/types": "8.53.1",
@@ -3802,9 +3795,8 @@
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3839,7 +3831,7 @@
       "version": "8.3.4",
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
       "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.11.0"
@@ -3854,7 +3846,6 @@
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -4023,7 +4014,7 @@
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
       "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/argparse": {
@@ -4350,7 +4341,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4572,7 +4562,6 @@
       "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "readdirp": "^4.0.1"
       },
@@ -4620,15 +4609,13 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.5.1.tgz",
       "integrity": "sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/class-validator": {
       "version": "0.14.3",
       "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.14.3.tgz",
       "integrity": "sha512-rXXekcjofVN1LTOSw+u4u9WXVEUvNBVjORW154q/IdmYWy1nMbOU9aNtZB0t8m+FJQ9q91jlr2f9CwwUFdFMRA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/validator": "^13.15.3",
         "libphonenumber-js": "^1.11.1",
@@ -4947,7 +4934,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/cron": {
@@ -5111,7 +5098,7 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
       "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
@@ -5324,7 +5311,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5385,7 +5371,6 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -6795,7 +6780,6 @@
       "integrity": "sha512-F26gjC0yWN8uAA5m5Ss8ZQf5nDHWGlN/xWZIh8S5SRbsEKBovwZhxGd6LJlbZYxBgCYOtreSUyb8hpXyGC5O4A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "30.2.0",
         "@jest/types": "30.2.0",
@@ -7893,7 +7877,7 @@
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
       "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/makeerror": {
@@ -8554,7 +8538,6 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.17.2.tgz",
       "integrity": "sha512-vjbKdiBJRqzcYw1fNU5KuHyYvdJ1qpcQg1CeBrHFqV1pWgHeVR6j/+kX0E1AAXfyuLUGY1ICrN2ELKA/z2HWzw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.10.1",
         "pg-pool": "^3.11.0",
@@ -8812,7 +8795,6 @@
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -9018,8 +9000,7 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
       "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
@@ -9150,7 +9131,6 @@
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -9812,7 +9792,6 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -10158,9 +10137,8 @@
       "version": "10.9.2",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -10367,7 +10345,6 @@
       "resolved": "https://registry.npmjs.org/typeorm/-/typeorm-0.3.28.tgz",
       "integrity": "sha512-6GH7wXhtfq2D33ZuRXYwIsl/qM5685WZcODZb7noOOcRMteM9KF2x2ap3H0EBjnSV0VO4gNAfJT5Ukp0PkOlvg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@sqltools/formatter": "^1.2.5",
         "ansis": "^4.2.0",
@@ -10560,9 +10537,8 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -10763,7 +10739,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
       "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/v8-to-istanbul": {
@@ -10839,7 +10815,6 @@
       "integrity": "sha512-Qphch25abbMNtekmEGJmeRUhLDbe+QfiWTiqpKYkpCOWY64v9eyl+KRRLmqOFA2AvKPpc9DC6+u2n76tQLBoaA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -10909,7 +10884,6 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -11188,7 +11162,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
       "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"

--- a/src/common/crypto/encryption.util.spec.ts
+++ b/src/common/crypto/encryption.util.spec.ts
@@ -1,0 +1,59 @@
+import { SecretEncryptionUtil } from './secret-encryption.util.js';
+import * as crypto from 'crypto';
+
+describe('SecretEncryptionUtil', () => {
+  const validKey = crypto.randomBytes(32).toString('hex');
+  const plaintext = 'SCZANGBA5YHTNYVSKOP3SJ2CAANRL5ZVTTHLQPTU26HQZQVTYVKBMCR';
+
+  describe('encrypt', () => {
+    it('produces a colon-separated string with three parts', () => {
+      const result = SecretEncryptionUtil.encrypt(plaintext, validKey);
+      expect(result.split(':').length).toBe(3);
+    });
+
+    it('produces a different output each call due to random IV', () => {
+      const first = SecretEncryptionUtil.encrypt(plaintext, validKey);
+      const second = SecretEncryptionUtil.encrypt(plaintext, validKey);
+      expect(first).not.toBe(second);
+    });
+  });
+
+  describe('decrypt', () => {
+    it('round-trips correctly', () => {
+      const encrypted = SecretEncryptionUtil.encrypt(plaintext, validKey);
+      const decrypted = SecretEncryptionUtil.decrypt(encrypted, validKey);
+      expect(decrypted).toBe(plaintext);
+    });
+
+    it('throws when the wrong key is used', () => {
+      const encrypted = SecretEncryptionUtil.encrypt(plaintext, validKey);
+      const wrongKey = crypto.randomBytes(32).toString('hex');
+      expect(() => SecretEncryptionUtil.decrypt(encrypted, wrongKey)).toThrow();
+    });
+
+    it('throws when the ciphertext is tampered with', () => {
+      const encrypted = SecretEncryptionUtil.encrypt(plaintext, validKey);
+      const parts = encrypted.split(':');
+      parts[2] = 'aabbccdd'; // corrupt the ciphertext
+      expect(() =>
+        SecretEncryptionUtil.decrypt(parts.join(':'), validKey),
+      ).toThrow();
+    });
+
+    it('throws a descriptive error for legacy base64 format', () => {
+      const base64Secret = Buffer.from(plaintext).toString('base64');
+      expect(() =>
+        SecretEncryptionUtil.decrypt(base64Secret, validKey),
+      ).toThrow('Invalid encrypted format');
+    });
+  });
+
+  describe('key validation', () => {
+    it('throws when key is wrong length', () => {
+      const shortKey = 'abc123';
+      expect(() => SecretEncryptionUtil.encrypt(plaintext, shortKey)).toThrow(
+        'Encryption key must be 32 bytes',
+      );
+    });
+  });
+});

--- a/src/common/crypto/secret-encryption.util.ts
+++ b/src/common/crypto/secret-encryption.util.ts
@@ -1,0 +1,80 @@
+import * as crypto from 'crypto';
+
+/**
+ * SecretEncryptionUtil
+ *
+ * Shared AES-256-GCM encryption utility for ephemeral account secret keys.
+ * Used by AccountsService (encrypt on creation) and ClaimRedemptionProvider
+ * (decrypt on claim redemption). Both must always use this single implementation
+ * - never inline encrypt/decrypt logic elsewhere.
+ *
+ * Encrypted format (colon-separated hex strings):
+ *   iv:authTag:encryptedData
+ *
+ * The IV is randomly generated per call - never reused.
+ * The GCM auth tag detects any tampering with the ciphertext.
+ *
+ * Key requirements:
+ * - Must be a 32-byte value provided as a 64-character hex string
+ * - Sourced from ENCRYPTION_KEY environment variable
+ * - Generate with: node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
+ */
+export class SecretEncryptionUtil {
+  private static readonly ALGORITHM = 'aes-256-gcm';
+  private static readonly IV_LENGTH = 16;
+
+  static encrypt(plaintext: string, encryptionKey: string): string {
+    const key = SecretEncryptionUtil.parseKey(encryptionKey);
+    const iv = crypto.randomBytes(SecretEncryptionUtil.IV_LENGTH);
+    const cipher = crypto.createCipheriv(
+      SecretEncryptionUtil.ALGORITHM,
+      key,
+      iv,
+    );
+    const encrypted = Buffer.concat([
+      cipher.update(plaintext, 'utf8'),
+      cipher.final(),
+    ]);
+    const authTag = cipher.getAuthTag();
+    return [
+      iv.toString('hex'),
+      authTag.toString('hex'),
+      encrypted.toString('hex'),
+    ].join(':');
+  }
+
+  static decrypt(encryptedString: string, encryptionKey: string): string {
+    const key = SecretEncryptionUtil.parseKey(encryptionKey);
+    const parts = encryptedString.split(':');
+    if (parts.length !== 3) {
+      throw new Error(
+        'Invalid encrypted format. Expected iv:authTag:encryptedData. ' +
+          'This may be a legacy base64-encoded secret that has not been migrated.',
+      );
+    }
+    const [ivHex, authTagHex, dataHex] = parts;
+    const iv = Buffer.from(ivHex, 'hex');
+    const authTag = Buffer.from(authTagHex, 'hex');
+    const data = Buffer.from(dataHex, 'hex');
+    const decipher = crypto.createDecipheriv(
+      SecretEncryptionUtil.ALGORITHM,
+      key,
+      iv,
+    );
+    decipher.setAuthTag(authTag);
+    return Buffer.concat([decipher.update(data), decipher.final()]).toString(
+      'utf8',
+    );
+  }
+
+  private static parseKey(hexKey: string): Buffer {
+    const key = Buffer.from(hexKey, 'hex');
+    if (key.length !== 32) {
+      throw new Error(
+        `Encryption key must be 32 bytes (64 hex characters). Got ${key.length} bytes. ` +
+          "Generate a valid key with: node -e \"console.log(require('crypto').randomBytes(32).toString('hex'))\"",
+      );
+    }
+    return key;
+  }
+}

--- a/src/modules/accounts/accounts.service.ts
+++ b/src/modules/accounts/accounts.service.ts
@@ -9,6 +9,7 @@ import { JwtService } from '@nestjs/jwt';
 import * as crypto from 'crypto';
 import { ConfigService } from '@nestjs/config';
 import { AccountStatus } from './enums/account-status.enum.js';
+import { SecretEncryptionUtil } from '../../common/crypto/secret-encryption.util.js';
 
 /**
  * AccountsService — Service-Level Documentation & Contributor Guidance
@@ -98,11 +99,14 @@ export class AccountsService {
     private configService: ConfigService,
     private jwtService: JwtService,
     private stellarService: StellarService,
+    private readonly encryptionKey: string,
   ) {
     this.ENCRYPTION_KEY = Buffer.from(
       this.configService.getOrThrow<string>('stellar.encryptionKey'),
       'hex',
     );
+    this.encryptionKey =
+      this.configService.getOrThrow<string>('app.encryptionKey');
   }
 
   public async create(
@@ -127,7 +131,10 @@ export class AccountsService {
     // if the Stellar/contract steps fail
     const account = this.accountsRepository.create({
       publicKey: ephemeralKeypair.publicKey(),
-      secretKeyEncrypted: this.encryptSecret(ephemeralKeypair.secret()),
+      secretKeyEncrypted: SecretEncryptionUtil.encrypt(
+        ephemeralKeypair.secret(),
+        this.encryptionKey,
+      ),
       fundingSource: createAccountDto.fundingSource,
       amount: createAccountDto.amount,
       asset: createAccountDto.asset,
@@ -251,23 +258,6 @@ export class AccountsService {
     //   systems and email templates may rely on the shape of this URL.
     const baseUrl = process.env.CLAIM_BASE_URL || 'https://claim.bridgelet.io';
     return `${baseUrl}/c/${token}`;
-  }
-
-  private encryptSecret(secret: string): string {
-    const iv = crypto.randomBytes(this.IV_LENGTH);
-    const cipher = crypto.createCipheriv(
-      'aes-256-gcm',
-      this.ENCRYPTION_KEY,
-      iv,
-    );
-
-    const encrypted = Buffer.concat([
-      cipher.update(secret, 'utf8'),
-      cipher.final(),
-    ]);
-    const authTag = cipher.getAuthTag();
-
-    return `${iv.toString('hex')}:${authTag.toString('hex')}:${encrypted.toString('hex')}`;
   }
 
   /**

--- a/src/modules/claims/providers/claim-redemption.provider.spec.ts
+++ b/src/modules/claims/providers/claim-redemption.provider.spec.ts
@@ -7,6 +7,8 @@ import { Claim } from '../entities/claim.entity.js';
 import { Account } from '../../accounts/entities/account.entity.js';
 import { SweepsService } from '../../sweeps/sweeps.service.js';
 import { AccountStatus } from '../../accounts/enums/account-status.enum.js';
+import { ConfigService } from '@nestjs/config';
+import { SecretEncryptionUtil } from '../../../common/crypto/secret-encryption.util.js';
 
 describe('ClaimRedemptionProvider', () => {
   let provider: ClaimRedemptionProvider;
@@ -85,9 +87,19 @@ describe('ClaimRedemptionProvider', () => {
           provide: SweepsService,
           useValue: mockSweepsService,
         },
+        {
+          provide: ConfigService,
+          useValue: {
+            get: jest.fn().mockReturnValue('mock-value'),
+            getOrThrow: jest.fn().mockReturnValue(
+              'a'.repeat(64), // 64 hex chars = 32 bytes
+            ),
+          },
+        },
       ],
     }).compile();
 
+    jest.spyOn(SecretEncryptionUtil, 'decrypt').mockReturnValue('test-secret');
     provider = module.get<ClaimRedemptionProvider>(ClaimRedemptionProvider);
 
     // Default happy-path mocks shared across tests

--- a/src/modules/claims/providers/claim-redemption.provider.ts
+++ b/src/modules/claims/providers/claim-redemption.provider.ts
@@ -13,6 +13,8 @@ import { ClaimRedemptionResponseDto } from '../dto/claim-redemption-response.dto
 import { SweepsService } from '../../sweeps/sweeps.service.js';
 import { TokenVerificationProvider } from './token-verification.provider.js';
 import { AccountStatus } from '../../accounts/enums/account-status.enum.js';
+import { SecretEncryptionUtil } from '../../../common/crypto/secret-encryption.util.js';
+import { ConfigService } from '@nestjs/config';
 
 @Injectable()
 export class ClaimRedemptionProvider {
@@ -25,6 +27,7 @@ export class ClaimRedemptionProvider {
     private accountsRepository: Repository<Account>,
     private tokenVerificationProvider: TokenVerificationProvider,
     private sweepsService: SweepsService,
+    private configService: ConfigService,
     // TEMPORARY: WebhooksService not yet implemented - commented out to allow dev server to start
     // private webhooksService: WebhooksService,
   ) {}
@@ -115,7 +118,11 @@ export class ClaimRedemptionProvider {
       const sweepResult = await this.sweepsService.executeSweep({
         accountId: account.id,
         ephemeralPublicKey: account.publicKey,
-        ephemeralSecret: this.decryptSecret(account.secretKeyEncrypted),
+        ephemeralSecret: SecretEncryptionUtil.decrypt(
+          account.secretKeyEncrypted,
+          this.configService.getOrThrow<string>('app.encryptionKey'),
+        ),
+
         destinationAddress,
         amount: account.amount,
         asset: account.asset,
@@ -190,11 +197,5 @@ export class ClaimRedemptionProvider {
 
   private hashToken(token: string): string {
     return crypto.createHash('sha256').update(token).digest('hex');
-  }
-
-  private decryptSecret(encrypted: string): string {
-    // TODO: Implement proper decryption (AES-256)
-    // For MVP, using base64 (NOT SECURE for production)
-    return Buffer.from(encrypted, 'base64').toString('utf-8');
   }
 }


### PR DESCRIPTION
Closes #93 

Summary:

Secret encryption/decryption logic was duplicated or scattered across modules. This PR moves that logic into SecretEncryptionUtil, a single shared utility, so all modules that need to encrypt or decrypt sensitive values (e.g. ephemeral secret keys) use one consistent, tested implementation instead of reimplementing crypto logic ad hoc.
Changes:

Introduced SecretEncryptionUtil under common/crypto with encrypt/decrypt methods.
Replaced inline encryption/decryption calls (e.g. in ClaimRedemptionProvider) with calls to the shared utility.
Centralized the encryption key retrieval via ConfigService (app.encryptionKey) rather than duplicating config access per call site.

Why:

Reduces risk of inconsistent or insecure crypto implementations across the codebase, makes key rotation/algorithm changes a single-point update, and simplifies testing of encryption behavior.
Testing:

Verified existing claim redemption flow still encrypts/decrypts ephemeral secrets correctly.
Added/updated unit tests for SecretEncryptionUtil.