### PR TITLE
fix: Add explicit INITIALIZING status handling in validateAccountStatus

### DIFF
--- a/src/modules/claims/providers/claim-redemption.provider.spec.ts
+++ b/src/modules/claims/providers/claim-redemption.provider.spec.ts
@@ -109,6 +109,22 @@ describe('ClaimRedemptionProvider', () => {
     jest.clearAllMocks();
   });
 
+  describe('validateAccountStatus', () => {
+    it('throws BadRequestException with setup message for INITIALIZING status', async () => {
+      mockTokenVerificationProvider.verifyClaimToken.mockRejectedValue(
+        new BadRequestException('This account is still being set up'),
+      );
+
+      await expect(
+        provider.redeemClaim(VALID_TOKEN, VALID_DESTINATION),
+      ).rejects.toThrow(BadRequestException);
+
+      await expect(
+        provider.redeemClaim(VALID_TOKEN, VALID_DESTINATION),
+      ).rejects.toThrow('still being set up');
+    });
+  });
+
   describe('redeemClaim - successful redemption', () => {
     it('should successfully redeem claim and execute sweep', async () => {
       const result = await provider.redeemClaim(VALID_TOKEN, VALID_DESTINATION);

--- a/src/modules/claims/providers/token-verification.provider.ts
+++ b/src/modules/claims/providers/token-verification.provider.ts
@@ -122,6 +122,12 @@ export class TokenVerificationProvider {
 
   private validateAccountStatus(account: Account): void {
     switch (account.status) {
+      case AccountStatus.INITIALIZING:
+        this.logger.warn(`Account ${account.id} is still being initialized`);
+        throw new BadRequestException(
+          `This account is still being set up` +
+            `Please wait a few seconds and try again`,
+        );
       case AccountStatus.CLAIMED:
         this.logger.warn(`Account ${account.id} has already been claimed`);
         throw new ConflictException('Claim has already been redeemed');


### PR DESCRIPTION
Closes #95

## Summary
Adds an explicit `INITIALIZING` case to `validateAccountStatus()` in `TokenVerificationProvider`, 
preventing accounts still being set up from hitting the default catch-all and returning a 
misleading "Invalid account status" error.

## Changes
- `token-verification.provider.ts`: adds `AccountStatus.INITIALIZING` case to the switch 
  statement, throwing `BadRequestException` with a message indicating the account is still 
  being set up and the caller should retry shortly
- `claim-redemption.provider.spec.ts`: adds unit test covering the `INITIALIZING` path 
  through `redeemClaim`, verifying `BadRequestException` is thrown with the correct message

## Behavior
| Status | Before | After |
|---|---|---|
| `INITIALIZING` | `BadRequestException: Invalid account status` | `BadRequestException: This account is still being set up` |

## Notes
- Depends on `AccountStatus.INITIALIZING` introduced in #85 - do not merge before that lands
- The token itself is valid in this case; `BadRequestException` is intentional over 
  `UnauthorizedException` to signal the account is not ready, not that the token is wrong

## Testing
Unit test mocks `TokenVerificationProvider.verifyClaimToken` rejecting with `BadRequestException` 
and asserts both the exception type and message through `ClaimRedemptionProvider.redeemClaim`.