### PR TITLE
fix: Prevent 'pending' from being saved as sweep transaction hash

### DIFF
--- a/src/common/validators/transaction-hash.validator.spec.ts
+++ b/src/common/validators/transaction-hash.validator.spec.ts
@@ -30,7 +30,9 @@ describe('TransactionHashValidator', () => {
     });
 
     it('accepts uppercase hex', () => {
-      expect(TransactionHashValidator.isValid(validHash.toUpperCase())).toBe(true);
+      expect(TransactionHashValidator.isValid(validHash.toUpperCase())).toBe(
+        true,
+      );
     });
   });
 
@@ -42,15 +44,15 @@ describe('TransactionHashValidator', () => {
     });
 
     it('throws for the string pending', () => {
-      expect(() =>
-        TransactionHashValidator.assertValid('pending'),
-      ).toThrow('Invalid transaction hash');
+      expect(() => TransactionHashValidator.assertValid('pending')).toThrow(
+        'Invalid transaction hash',
+      );
     });
 
     it('throws with the invalid value in the message', () => {
-      expect(() =>
-        TransactionHashValidator.assertValid('pending'),
-      ).toThrow('"pending"');
+      expect(() => TransactionHashValidator.assertValid('pending')).toThrow(
+        '"pending"',
+      );
     });
 
     it('throws for an empty string', () => {

--- a/src/common/validators/transaction-hash.validator.spec.ts
+++ b/src/common/validators/transaction-hash.validator.spec.ts
@@ -1,0 +1,60 @@
+﻿import { TransactionHashValidator } from './transaction-hash.validator.js';
+
+describe('TransactionHashValidator', () => {
+  const validHash =
+    '571a84bc59fefb3fd17fe167b9c76286e83c31972649441a2d09da87f5b997a7';
+
+  describe('isValid', () => {
+    it('returns true for a valid 64-char hex hash', () => {
+      expect(TransactionHashValidator.isValid(validHash)).toBe(true);
+    });
+
+    it('returns false for the string pending', () => {
+      expect(TransactionHashValidator.isValid('pending')).toBe(false);
+    });
+
+    it('returns false for a hash that is too short', () => {
+      expect(TransactionHashValidator.isValid('abc123')).toBe(false);
+    });
+
+    it('returns false for a hash that is too long', () => {
+      expect(TransactionHashValidator.isValid(validHash + 'ff')).toBe(false);
+    });
+
+    it('returns false for empty string', () => {
+      expect(TransactionHashValidator.isValid('')).toBe(false);
+    });
+
+    it('returns false for null without throwing', () => {
+      expect(TransactionHashValidator.isValid(null as any)).toBe(false);
+    });
+
+    it('accepts uppercase hex', () => {
+      expect(TransactionHashValidator.isValid(validHash.toUpperCase())).toBe(true);
+    });
+  });
+
+  describe('assertValid', () => {
+    it('does not throw for a valid hash', () => {
+      expect(() =>
+        TransactionHashValidator.assertValid(validHash),
+      ).not.toThrow();
+    });
+
+    it('throws for the string pending', () => {
+      expect(() =>
+        TransactionHashValidator.assertValid('pending'),
+      ).toThrow('Invalid transaction hash');
+    });
+
+    it('throws with the invalid value in the message', () => {
+      expect(() =>
+        TransactionHashValidator.assertValid('pending'),
+      ).toThrow('"pending"');
+    });
+
+    it('throws for an empty string', () => {
+      expect(() => TransactionHashValidator.assertValid('')).toThrow();
+    });
+  });
+});

--- a/src/common/validators/transaction-hash.validator.ts
+++ b/src/common/validators/transaction-hash.validator.ts
@@ -10,8 +10,8 @@
     if (!TransactionHashValidator.isValid(hash)) {
       throw new Error(
         `Invalid transaction hash: "${hash}". ` +
-        'Expected a 64-character hex string. ' +
-        'The sweep transaction may not have completed successfully.',
+          'Expected a 64-character hex string. ' +
+          'The sweep transaction may not have completed successfully.',
       );
     }
   }

--- a/src/common/validators/transaction-hash.validator.ts
+++ b/src/common/validators/transaction-hash.validator.ts
@@ -1,0 +1,18 @@
+﻿export class TransactionHashValidator {
+  private static readonly STELLAR_TX_HASH_REGEX = /^[a-f0-9]{64}$/i;
+
+  static isValid(hash: string): boolean {
+    if (!hash || typeof hash !== 'string') return false;
+    return TransactionHashValidator.STELLAR_TX_HASH_REGEX.test(hash);
+  }
+
+  static assertValid(hash: string): void {
+    if (!TransactionHashValidator.isValid(hash)) {
+      throw new Error(
+        `Invalid transaction hash: "${hash}". ` +
+        'Expected a 64-character hex string. ' +
+        'The sweep transaction may not have completed successfully.',
+      );
+    }
+  }
+}

--- a/src/modules/claims/entities/claim.entity.ts
+++ b/src/modules/claims/entities/claim.entity.ts
@@ -27,7 +27,14 @@ export class Claim {
   @Column({ type: 'varchar', length: 56 })
   destinationAddress: string;
 
-  @Column({ type: 'varchar', length: 64 })
+  @Column({
+    type: 'varchar',
+    length: 64,
+    comment:
+      'Stellar transaction hash of the sweep. ' +
+      'Always a 64-character hex string — never a placeholder value. ' +
+      'Enforced by TransactionHashValidator before record creation.',
+  })
   sweepTxHash: string;
 
   @Column({ type: 'varchar', length: 100 })

--- a/src/modules/claims/providers/claim-redemption.provider.spec.ts
+++ b/src/modules/claims/providers/claim-redemption.provider.spec.ts
@@ -53,7 +53,7 @@ describe('ClaimRedemptionProvider', () => {
   };
 
   const mockSweepResult = {
-    txHash: 'sweep-tx-hash-abc123',
+    txHash: 'a'.repeat(64),
     success: true,
   };
 

--- a/src/modules/claims/providers/claim-redemption.provider.ts
+++ b/src/modules/claims/providers/claim-redemption.provider.ts
@@ -12,7 +12,6 @@ import { Account } from '../../accounts/entities/account.entity.js';
 import { ClaimRedemptionResponseDto } from '../dto/claim-redemption-response.dto.js';
 import { SweepsService } from '../../sweeps/sweeps.service.js';
 import { TokenVerificationProvider } from './token-verification.provider.js';
-
 import { AccountStatus } from '../../accounts/enums/account-status.enum.js';
 import { SecretEncryptionUtil } from '../../../common/crypto/secret-encryption.util.js';
 import { ConfigService } from '@nestjs/config';

--- a/src/modules/claims/providers/claim-redemption.provider.ts
+++ b/src/modules/claims/providers/claim-redemption.provider.ts
@@ -15,6 +15,7 @@ import {
 import { ClaimRedemptionResponseDto } from '../dto/claim-redemption-response.dto.js';
 import { SweepsService } from '../../sweeps/sweeps.service.js';
 import { TokenVerificationProvider } from './token-verification.provider.js';
+import { TransactionHashValidator } from '../../../common/validators/transaction-hash.validator.js';
 
 @Injectable()
 export class ClaimRedemptionProvider {
@@ -122,6 +123,10 @@ export class ClaimRedemptionProvider {
         amount: account.amount,
         asset: account.asset,
       });
+
+      // Guard: never persist a placeholder or invalid hash.
+      // If this throws, the outer catch block will roll back account status.
+      TransactionHashValidator.assertValid(sweepResult.txHash);
 
       // Create claim record
       const claim = this.claimsRepository.create({


### PR DESCRIPTION
Closes #97

## What this does

- Added `TransactionHashValidator` in `src/common/validators/transaction-hash.validator.ts` to verify a string is a real 64-character hex Stellar transaction hash
- Added unit tests in `transaction-hash.validator.spec.ts` covering valid hashes, the placeholder string "pending", empty/null/wrong-length strings, and uppercase hex
- `ClaimRedemptionProvider.redeemClaim()` now calls `TransactionHashValidator.assertValid()` right after `executeSweep()` and before the Claim record is created. If the hash is invalid, it throws, and the existing catch block rolls back the account status to PENDING_CLAIM — no Claim record gets persisted with a fake hash.
- Documented the constraint on the `sweepTxHash` column in `claim.entity.ts` with a comment explaining it must always be a real 64-character hex string, enforced by `TransactionHashValidator`.

## On the sweepTxHash column length

The column is `varchar(64)`, which exactly matches the length of a real Stellar transaction hash (64 hex characters), so no migration is needed for this fix. There is no extra room in the column for anything else (e.g. a placeholder string like "pending" would have technically fit before, which was part of the problem). If a future requirement needs to store additional metadata alongside the hash, that would require a separate column/migration rather than resizing this one.