### PR TITLE
feat(stellar): add trace logging for expiresIn → expiry_ledger conversion

### DIFF
--- a/src/modules/stellar/stellar.service.ts
+++ b/src/modules/stellar/stellar.service.ts
@@ -117,6 +117,12 @@ export class StellarService {
     // Step 2: Initialize the Soroban contract with restrictions
     const expiryLedger = await this.toExpiryLedger(params.expiresIn);
 
+    this.logger.log(
+      `Expiry conversion: expiresIn=${params.expiresIn}s → expiryLedger=${expiryLedger} ` +
+        `(currentLedger=${Math.round(expiryLedger - Math.ceil(params.expiresIn / 5) - EXPIRY_BUFFER_LEDGERS)}, ` +
+        `offset=${expiryLedger - Math.round(expiryLedger - Math.ceil(params.expiresIn / 5) - EXPIRY_BUFFER_LEDGERS)} ledgers)`,
+    );
+
     const contract = new StellarSdk.Contract(params.contractId);
     const sourceAccount = await this.sorobanServer.getAccount(
       fundingKeypair.publicKey(),


### PR DESCRIPTION
## Summary

Adds runtime trace logging in `createEphemeralAccount()` to verify the `expiresIn → expiry_ledger` conversion is working correctly.

## Changes

- Log the full conversion: `expiresIn` (seconds) → `expiryLedger` (ledger sequence)
- Includes currentLedger and offset for debugging
- Helps operators verify accounts are initialized with correct expiry in production

## Verification

The full chain `CreateAccountDto.expiresIn → AccountsService.create() → StellarService.createEphemeralAccount() → toExpiryLedger() → contract call` is already correctly wired. This PR adds observability to confirm it at runtime.

Related to #144