### PR TITLE
Feature: Validate and sanitise account metadata field (#20)

### DIFF
--- a/src/common/utils/metadata-sanitizer.util.spec.ts
+++ b/src/common/utils/metadata-sanitizer.util.spec.ts
@@ -1,0 +1,64 @@
+import { BadRequestException } from '@nestjs/common';
+import {
+  sanitizeMetadata,
+  METADATA_MAX_BYTES,
+} from './metadata-sanitizer.util.js';
+
+describe('sanitizeMetadata', () => {
+  it('returns undefined for null input', () => {
+    expect(sanitizeMetadata(null)).toBeUndefined();
+  });
+
+  it('returns undefined for undefined input', () => {
+    expect(sanitizeMetadata(undefined)).toBeUndefined();
+  });
+
+  it('passes through safe keys unchanged', () => {
+    const result = sanitizeMetadata({ userId: 'u123', orderId: 'o456' });
+    expect(result).toEqual({ userId: 'u123', orderId: 'o456' });
+  });
+
+  it('strips top-level PII keys: email, phone', () => {
+    const result = sanitizeMetadata({
+      userId: 'u1',
+      email: 'user@example.com',
+      phone: '555-1234',
+    });
+    expect(result).not.toHaveProperty('email');
+    expect(result).not.toHaveProperty('phone');
+    expect(result).toHaveProperty('userId', 'u1');
+  });
+
+  it('strips PII keys case-insensitively (Email, PHONE)', () => {
+    const result = sanitizeMetadata({ Email: 'x@y.com', PHONE: '1234' });
+    expect(result).not.toHaveProperty('Email');
+    expect(result).not.toHaveProperty('PHONE');
+  });
+
+  it.each([
+    'email', 'phone', 'phonenumber', 'mobile', 'ssn', 'dob',
+    'dateofbirth', 'address', 'fullname', 'firstname', 'lastname',
+    'name', 'nationalid', 'passport', 'taxid',
+  ])('strips the PII key "%s"', (key) => {
+    const result = sanitizeMetadata({ [key]: 'sensitive', safe: 'ok' });
+    expect(result).not.toHaveProperty(key);
+    expect(result).toHaveProperty('safe', 'ok');
+  });
+
+  it('throws BadRequestException when metadata exceeds METADATA_MAX_BYTES', () => {
+    const large = { data: 'x'.repeat(METADATA_MAX_BYTES + 1) };
+    expect(() => sanitizeMetadata(large)).toThrow(BadRequestException);
+  });
+
+  it('accepts metadata exactly at the byte limit', () => {
+    // Build a payload whose JSON serialisation is exactly METADATA_MAX_BYTES
+    const value = 'x'.repeat(METADATA_MAX_BYTES - '{"data":""}' .length);
+    const result = sanitizeMetadata({ data: value });
+    expect(result).toHaveProperty('data');
+  });
+
+  it('returns an empty object when all keys are PII', () => {
+    const result = sanitizeMetadata({ email: 'a@b.com', phone: '123' });
+    expect(result).toEqual({});
+  });
+});

--- a/src/common/utils/metadata-sanitizer.util.spec.ts
+++ b/src/common/utils/metadata-sanitizer.util.spec.ts
@@ -36,9 +36,21 @@ describe('sanitizeMetadata', () => {
   });
 
   it.each([
-    'email', 'phone', 'phonenumber', 'mobile', 'ssn', 'dob',
-    'dateofbirth', 'address', 'fullname', 'firstname', 'lastname',
-    'name', 'nationalid', 'passport', 'taxid',
+    'email',
+    'phone',
+    'phonenumber',
+    'mobile',
+    'ssn',
+    'dob',
+    'dateofbirth',
+    'address',
+    'fullname',
+    'firstname',
+    'lastname',
+    'name',
+    'nationalid',
+    'passport',
+    'taxid',
   ])('strips the PII key "%s"', (key) => {
     const result = sanitizeMetadata({ [key]: 'sensitive', safe: 'ok' });
     expect(result).not.toHaveProperty(key);
@@ -52,7 +64,7 @@ describe('sanitizeMetadata', () => {
 
   it('accepts metadata exactly at the byte limit', () => {
     // Build a payload whose JSON serialisation is exactly METADATA_MAX_BYTES
-    const value = 'x'.repeat(METADATA_MAX_BYTES - '{"data":""}' .length);
+    const value = 'x'.repeat(METADATA_MAX_BYTES - '{"data":""}'.length);
     const result = sanitizeMetadata({ data: value });
     expect(result).toHaveProperty('data');
   });

--- a/src/common/utils/metadata-sanitizer.util.ts
+++ b/src/common/utils/metadata-sanitizer.util.ts
@@ -1,0 +1,54 @@
+import { BadRequestException } from '@nestjs/common';
+
+/** Maximum allowed serialised size of metadata (4 KB). */
+export const METADATA_MAX_BYTES = 4096;
+
+/**
+ * Keys whose values may contain PII and should be stripped before storage.
+ * All comparisons are case-insensitive.
+ */
+const PII_KEYS = new Set([
+  'email',
+  'phone',
+  'phonenumber',
+  'mobile',
+  'ssn',
+  'dob',
+  'dateofbirth',
+  'address',
+  'fullname',
+  'firstname',
+  'lastname',
+  'name',
+  'nationalid',
+  'passport',
+  'taxid',
+]);
+
+/**
+ * Validates that metadata does not exceed METADATA_MAX_BYTES when serialised,
+ * then strips any top-level keys that look like PII.
+ *
+ * @throws BadRequestException when the serialised metadata exceeds the limit.
+ * @returns A sanitised copy with PII keys removed (or undefined if input is falsy).
+ */
+export function sanitizeMetadata(
+  metadata: Record<string, unknown> | null | undefined,
+): Record<string, unknown> | undefined {
+  if (!metadata) return undefined;
+
+  const serialised = JSON.stringify(metadata);
+  if (Buffer.byteLength(serialised, 'utf8') > METADATA_MAX_BYTES) {
+    throw new BadRequestException(
+      `metadata exceeds maximum allowed size of ${METADATA_MAX_BYTES} bytes`,
+    );
+  }
+
+  const sanitised: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(metadata)) {
+    if (!PII_KEYS.has(key.toLowerCase())) {
+      sanitised[key] = value;
+    }
+  }
+  return sanitised;
+}

--- a/src/modules/accounts/accounts.service.ts
+++ b/src/modules/accounts/accounts.service.ts
@@ -11,6 +11,7 @@ import { ConfigService } from '@nestjs/config';
 import { AccountStatus } from './enums/account-status.enum.js';
 import { SecretEncryptionUtil } from '../../common/crypto/secret-encryption.util.js';
 import { WebhooksService } from '../webhooks/webhooks.service.js';
+import { sanitizeMetadata } from '../../common/utils/metadata-sanitizer.util.js';
 
 /**
  * AccountsService — Service-Level Documentation & Contributor Guidance
@@ -138,7 +139,7 @@ export class AccountsService {
       status: AccountStatus.INITIALIZING,
       claimTokenHash,
       expiresAt,
-      metadata: createAccountDto.metadata,
+      metadata: sanitizeMetadata(createAccountDto.metadata),
     });
 
     await this.accountsRepository.save(account);


### PR DESCRIPTION
## Summary

Implements issue #20: validate and sanitise the `metadata` field on account creation.

## Implementation

**`src/common/utils/metadata-sanitizer.util.ts`** — new utility:
- Throws `BadRequestException` if serialised metadata exceeds **4 KB**
- Strips top-level keys matching known PII identifiers (case-insensitive): `email`, `phone`, `phonenumber`, `mobile`, `ssn`, `dob`, `dateofbirth`, `address`, `fullname`, `firstname`, `lastname`, `name`, `nationalid`, `passport`, `taxid`

**`src/modules/accounts/accounts.service.ts`** — wired into `create()`:
```ts
metadata: sanitizeMetadata(createAccountDto.metadata),
```

## Tests

`src/common/utils/metadata-sanitizer.util.spec.ts` — 23 tests covering:
- null/undefined passthrough
- Safe keys preserved
- All 15 PII keys stripped (parametrised)
- Case-insensitive stripping
- Max-size enforcement
- Boundary (exactly at limit)

## Validation

- `npm run build` ✅
- `npm test` ✅ — 399 tests, 21 suites, all passing

## Closes

Closes #153
Closes #154
Closes #155
Closes #156