### PR TITLE
Feature: Refine CreateAccountDto with recovery_address and asset fields (#25)

### DIFF
--- a/src/modules/accounts/accounts.service.ts
+++ b/src/modules/accounts/accounts.service.ts
@@ -124,6 +124,12 @@ export class AccountsService {
       .update(claimToken)
       .digest('hex');
 
+    // Derive combined asset string from asset_code + asset_issuer when provided
+    const asset =
+      createAccountDto.asset_code && createAccountDto.asset_issuer
+        ? `${createAccountDto.asset_code}:${createAccountDto.asset_issuer}`
+        : (createAccountDto.asset_code ?? 'native');
+
     // Save with INITIALIZING status first so we have a DB record for cleanup
     // if the Stellar/contract steps fail
     const account = this.accountsRepository.create({
@@ -134,7 +140,7 @@ export class AccountsService {
       ),
       fundingSource: createAccountDto.fundingSource,
       amount: createAccountDto.amount,
-      asset: createAccountDto.asset,
+      asset,
       status: AccountStatus.INITIALIZING,
       claimTokenHash,
       expiresAt,
@@ -147,9 +153,9 @@ export class AccountsService {
       const txHash = await this.stellarService.createEphemeralAccount({
         publicKey: ephemeralKeypair.publicKey(),
         amount: createAccountDto.amount,
-        asset: createAccountDto.asset,
+        asset,
         expiresIn: createAccountDto.expiresIn,
-        recoveryAddress: createAccountDto.fundingSource,
+        recoveryAddress: createAccountDto.recovery_address,
         contractId: this.configService.getOrThrow<string>(
           'stellar.contracts.ephemeralAccount',
         ),

--- a/src/modules/accounts/dto/create-account.dto.spec.ts
+++ b/src/modules/accounts/dto/create-account.dto.spec.ts
@@ -10,8 +10,10 @@ const LONG_KEY = 'G' + 'A'.repeat(56); // 57 chars  ✗
 // A fully valid base object — all tests override only the field under test
 const validBase = {
   fundingSource: VALID_KEY,
+  recovery_address: VALID_KEY,
   amount: '100',
-  asset: 'USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5',
+  asset_code: 'USDC',
+  asset_issuer: 'GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5',
   expiresIn: 3600,
 };
 
@@ -67,62 +69,117 @@ describe('CreateAccountDto — fundingSource', () => {
   });
 });
 
-// ─── asset ────────────────────────────────────────────────────────────────────
+// ─── recovery_address ─────────────────────────────────────────────────────────
 
-describe('CreateAccountDto — asset', () => {
-  it('accepts a valid issued asset (USDC with full issuer key)', async () => {
-    const errors = await errorsFor({
-      asset: 'USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5',
-    });
-    expect(errors).not.toContain('asset');
+describe('CreateAccountDto — recovery_address', () => {
+  it('accepts a valid Stellar public key', async () => {
+    const errors = await errorsFor({ recovery_address: VALID_KEY });
+    expect(errors).not.toContain('recovery_address');
   });
 
-  it('accepts a valid alphanumeric code with minimal issuer (e.g. USDC1:G...)', async () => {
-    const errors = await errorsFor({
-      asset: 'USDC1:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5',
-    });
-    expect(errors).not.toContain('asset');
+  it('rejects a key that is too short', async () => {
+    const errors = await errorsFor({ recovery_address: SHORT_KEY });
+    expect(errors).toContain('recovery_address');
   });
 
-  it('accepts the special-case string "native"', async () => {
-    const errors = await errorsFor({ asset: 'native' });
-    expect(errors).not.toContain('asset');
+  it('rejects a key that is too long', async () => {
+    const errors = await errorsFor({ recovery_address: LONG_KEY });
+    expect(errors).toContain('recovery_address');
   });
 
-  it('rejects an asset code with no issuer (e.g. "USDC")', async () => {
-    const errors = await errorsFor({ asset: 'USDC' });
-    expect(errors).toContain('asset');
-  });
-
-  it('rejects an asset code that is too long (13 chars before colon)', async () => {
-    const errors = await errorsFor({
-      asset:
-        'TOOLONGCODE1X:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5',
-    });
-    expect(errors).toContain('asset');
-  });
-
-  it('rejects a lowercase asset code (e.g. "usdc:G...")', async () => {
-    const errors = await errorsFor({
-      asset: 'usdc:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5',
-    });
-    expect(errors).toContain('asset');
-  });
-
-  it('rejects an asset with an invalid issuer (wrong length)', async () => {
-    const errors = await errorsFor({ asset: 'USDC:GBADISSUER' });
-    expect(errors).toContain('asset');
-  });
-
-  it('rejects an asset with an invalid issuer (does not start with G)', async () => {
-    const errors = await errorsFor({
-      asset: 'USDC:ABBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5',
-    });
-    expect(errors).toContain('asset');
+  it('rejects a key not starting with G', async () => {
+    const errors = await errorsFor({ recovery_address: 'A' + 'A'.repeat(55) });
+    expect(errors).toContain('recovery_address');
   });
 
   it('rejects an empty string', async () => {
-    const errors = await errorsFor({ asset: '' });
-    expect(errors).toContain('asset');
+    const errors = await errorsFor({ recovery_address: '' });
+    expect(errors).toContain('recovery_address');
+  });
+
+  it('rejects when missing', async () => {
+    const errors = await errorsFor({ recovery_address: undefined });
+    expect(errors).toContain('recovery_address');
+  });
+});
+
+// ─── asset_code ───────────────────────────────────────────────────────────────
+
+describe('CreateAccountDto — asset_code', () => {
+  it('accepts a valid uppercase asset code', async () => {
+    const errors = await errorsFor({ asset_code: 'USDC' });
+    expect(errors).not.toContain('asset_code');
+  });
+
+  it('accepts a single-character code', async () => {
+    const errors = await errorsFor({
+      asset_code: 'X',
+      asset_issuer: undefined,
+    });
+    expect(errors).not.toContain('asset_code');
+  });
+
+  it('accepts a 12-character code (max length)', async () => {
+    const errors = await errorsFor({ asset_code: 'ABCDEFGHIJ12' });
+    expect(errors).not.toContain('asset_code');
+  });
+
+  it('rejects a lowercase code', async () => {
+    const errors = await errorsFor({ asset_code: 'usdc' });
+    expect(errors).toContain('asset_code');
+  });
+
+  it('rejects a code longer than 12 characters', async () => {
+    const errors = await errorsFor({ asset_code: 'TOOLONGCODE1X' });
+    expect(errors).toContain('asset_code');
+  });
+
+  it('rejects a code with special characters', async () => {
+    const errors = await errorsFor({ asset_code: 'USD!' });
+    expect(errors).toContain('asset_code');
+  });
+
+  it('is optional — omitting it produces no error', async () => {
+    const errors = await errorsFor({
+      asset_code: undefined,
+      asset_issuer: undefined,
+    });
+    expect(errors).not.toContain('asset_code');
+  });
+});
+
+// ─── asset_issuer ─────────────────────────────────────────────────────────────
+
+describe('CreateAccountDto — asset_issuer', () => {
+  it('accepts a valid Stellar public key as issuer', async () => {
+    const errors = await errorsFor({
+      asset_code: 'USDC',
+      asset_issuer: 'GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5',
+    });
+    expect(errors).not.toContain('asset_issuer');
+  });
+
+  it('rejects an invalid issuer key (wrong length)', async () => {
+    const errors = await errorsFor({
+      asset_code: 'USDC',
+      asset_issuer: 'GBADISSUER',
+    });
+    expect(errors).toContain('asset_issuer');
+  });
+
+  it('rejects an issuer not starting with G', async () => {
+    const errors = await errorsFor({
+      asset_code: 'USDC',
+      asset_issuer: 'ABBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5',
+    });
+    expect(errors).toContain('asset_issuer');
+  });
+
+  it('is not required when asset_code is absent', async () => {
+    const errors = await errorsFor({
+      asset_code: undefined,
+      asset_issuer: undefined,
+    });
+    expect(errors).not.toContain('asset_issuer');
   });
 });

--- a/src/modules/accounts/dto/create-account.dto.ts
+++ b/src/modules/accounts/dto/create-account.dto.ts
@@ -6,12 +6,14 @@ import {
   IsObject,
   Min,
   Max,
+  ValidateIf,
   Matches,
 } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
 import { IsStellarPublicKey } from '../../../common/validators/is-stellar-public-key.validator.js';
 
-const STELLAR_ASSET_REGEX = /^(native|[A-Z0-9]{1,12}:G[A-Z0-9]{55})$/;
+const ASSET_CODE_REGEX = /^[A-Z0-9]{1,12}$/;
+const ASSET_ISSUER_REGEX = /^G[A-Z0-9]{55}$/;
 
 export class CreateAccountDto {
   @ApiProperty({
@@ -25,28 +27,51 @@ export class CreateAccountDto {
   @IsStellarPublicKey()
   fundingSource: string;
 
+  @ApiProperty({
+    example: 'GRECOVERY...',
+    description:
+      'Stellar public key to recover funds to if the ephemeral account expires unclaimed. ' +
+      'Must be 56 characters, start with G, and contain only uppercase alphanumeric characters.',
+  })
+  @IsString()
+  @IsNotEmpty()
+  @IsStellarPublicKey()
+  recovery_address: string;
+
   @ApiProperty({ example: '100', description: 'Payment amount' })
   @IsString()
   @IsNotEmpty()
   amount: string;
 
   @ApiProperty({
-    example: 'USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5',
+    example: 'USDC',
     description:
-      'Asset to use for the ephemeral account. ' +
-      'Use "native" for XLM, or CODE:ISSUER for issued assets ' +
-      '(e.g. USDC:G...). CODE is 1 - 12 uppercase alphanumeric characters; ' +
-      'ISSUER must be a valid Stellar public key.',
+      'Asset code (1–12 uppercase alphanumeric characters). ' +
+      'Use "native" for XLM. Required when asset_issuer is provided.',
+    required: false,
   })
+  @IsOptional()
+  @IsString()
+  @Matches(ASSET_CODE_REGEX, {
+    message:
+      'asset_code must be 1–12 uppercase alphanumeric characters (e.g. USDC, XLM)',
+  })
+  asset_code?: string;
+
+  @ApiProperty({
+    example: 'GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5',
+    description:
+      'Stellar public key of the asset issuer. Required when asset_code is a non-native issued asset.',
+    required: false,
+  })
+  @ValidateIf((o: CreateAccountDto) => !!o.asset_code && o.asset_code !== 'XLM')
   @IsString()
   @IsNotEmpty()
-  @Matches(STELLAR_ASSET_REGEX, {
+  @Matches(ASSET_ISSUER_REGEX, {
     message:
-      'asset must be "native" (for XLM) or in the format CODE:ISSUER ' +
-      '(e.g. USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5), ' +
-      'where CODE is 1 - 12 uppercase alphanumeric characters and ISSUER is a valid Stellar public key',
+      'asset_issuer must be a valid Stellar public key (56 characters, starts with G)',
   })
-  asset: string;
+  asset_issuer?: string;
 
   @ApiProperty({
     example: 2592000,


### PR DESCRIPTION
## Summary

Refines `CreateAccountDto` to add `recovery_address` and split asset identification into `asset_code` / `asset_issuer` fields, making the DTO contract explicit and contract-aligned.

## Changes

### `CreateAccountDto`
- Added `recovery_address` (required): validated Stellar public key (G + 55 uppercase alphanumeric chars) used as the recovery destination when an account expires unclaimed
- Added `asset_code` (optional): 1–12 uppercase alphanumeric characters matching the Stellar asset code format
- Added `asset_issuer` (conditionally required): validated Stellar public key; required when `asset_code` is present and not a native/XLM asset
- Removed the combined `asset` field (was `native` or `CODE:ISSUER`) in favour of explicit separate fields

### `AccountsService`
- Uses `recovery_address` from DTO instead of mapping `fundingSource` to the recovery address
- Derives the combined asset string (`CODE:ISSUER` or `native`) from `asset_code` + `asset_issuer` before persisting and passing to `StellarService`

### Tests
- 24 DTO unit tests covering all new fields and validation rules
- Full suite: 384/384 passing

## Validation

- ✅ Tests: 384/384 passing
- ✅ Lint: 0 errors
- ✅ Build: clean

## Closes

Closes #157
Closes #158
Closes #159
Closes #160
