### PR TITLE
Feature: Add migration schema integration test (#174)

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ cp .env.example .env
 #   1718100001000-CreateClaimsTable              (claims table + FK to accounts)
 #   1718100002000-AddInitializingToAccountStatus (adds INITIALIZING to account_status enum)
 #   1718100003000-CreateWebhooksTable            (webhooks table)
+#   1718100004000-AddClaimingToAccountStatus     (adds CLAIMING to account_status enum)
 npm run migration:run
 
 # Start development server
@@ -140,6 +141,8 @@ npm run test:cov
 ```
 
 Coverage reports are generated in the `coverage/` directory. The build will fail if any metric (branches, functions, lines, statements) falls below 80%.
+
+The repository also includes an embedded-Postgres integration test in `src/database/migrations.integration.spec.ts` that starts a fresh PostgreSQL instance, runs all current migrations, verifies the resulting schema matches the TypeORM entities, checks the `account_status_enum` values, and confirms the `claims.accountId -> accounts.id` foreign key is enforced.
 
 To check coverage for a specific file:
 

--- a/docs/database-schema.md
+++ b/docs/database-schema.md
@@ -1,0 +1,19 @@
+# Database Schema
+
+The current schema is created entirely through the migrations in `src/database/migrations/`.
+
+## Tables
+
+- `accounts`: stores ephemeral account lifecycle data, including encrypted secret material, funding metadata, expiry timestamps, and optional claim metadata.
+- `claims`: stores completed claim records and references `accounts.id` through a cascading foreign key on `accountId`.
+- `webhooks`: stores outbound webhook subscriptions and delivery metadata.
+
+## Account Status Enum
+
+`account_status_enum` currently contains these values, in order:
+
+`initializing`, `pending_payment`, `pending_claim`, `claiming`, `claimed`, `expired`, `failed`
+
+## Migration Verification
+
+`src/database/migrations.integration.spec.ts` provisions a fresh embedded PostgreSQL database, applies every migration, verifies the resulting schema matches the TypeORM entity metadata, and checks that the `claims.accountId` foreign key is enforced.

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,7 @@
         "@types/uuid": "^10.0.0",
         "@typescript-eslint/eslint-plugin": "^8.53.0",
         "@typescript-eslint/parser": "^8.53.0",
+        "embedded-postgres": "^16.14.0-beta.17",
         "eslint": "^9.18.0",
         "eslint-config-prettier": "^10.0.1",
         "eslint-plugin-prettier": "^5.2.2",
@@ -765,6 +766,150 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@embedded-postgres/darwin-arm64": {
+      "version": "16.14.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@embedded-postgres/darwin-arm64/-/darwin-arm64-16.14.0-beta.17.tgz",
+      "integrity": "sha512-CB1DFZ08zfmNapx231rAJW74UZfs1jQmeGLwbQSaAIRVs2uqEdMhVNLwVlztFG3ZPSeuCsgTn/0yeYDmKF67og==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@embedded-postgres/darwin-x64": {
+      "version": "16.14.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@embedded-postgres/darwin-x64/-/darwin-x64-16.14.0-beta.17.tgz",
+      "integrity": "sha512-zikibpPYGWokfT/OFWNHCwerA3ZGat0ZyCIXOIbIucLBMDHztQ2WZQ9R5zil6oOxzElrMz2Q4aEOssGNrMDdyg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@embedded-postgres/linux-arm": {
+      "version": "16.14.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@embedded-postgres/linux-arm/-/linux-arm-16.14.0-beta.17.tgz",
+      "integrity": "sha512-N+ktKhkTHuRe/mobk0+OBISje3M6ht4dloSm7zNwpy/hzkZTiB6m1fE0P2lllnob4jbFIbrA3nTvlY4yfe4E6w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@embedded-postgres/linux-arm64": {
+      "version": "16.14.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@embedded-postgres/linux-arm64/-/linux-arm64-16.14.0-beta.17.tgz",
+      "integrity": "sha512-LNT9TXoOGR/RSop1PewcMtpuf1Dtg6sKU7sFA1ODqInRA8NoP15HyLekUHW5aWnruu4yfs1pcy6DaV39T556mQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@embedded-postgres/linux-ia32": {
+      "version": "16.14.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@embedded-postgres/linux-ia32/-/linux-ia32-16.14.0-beta.17.tgz",
+      "integrity": "sha512-SC2hO6hlc8zlC1z2eOMNMACXAKV93QYyLq5JMrwRfjGkl3wbc4kUm3TmKl1SjWBX1x+qAZbMTt72yv+KED5Mvw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@embedded-postgres/linux-ppc64": {
+      "version": "16.14.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@embedded-postgres/linux-ppc64/-/linux-ppc64-16.14.0-beta.17.tgz",
+      "integrity": "sha512-paVxxVlr7g6AZxCISk9AGNB3zc3c6qKAEzlisrJXlt5Jw1qalxNyKpfkUahDR9qbk+zGnL54PjEQDSUuomHx/g==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@embedded-postgres/linux-x64": {
+      "version": "16.14.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@embedded-postgres/linux-x64/-/linux-x64-16.14.0-beta.17.tgz",
+      "integrity": "sha512-8fr7hEiI7XlbPDPsLZJ4RU1NR6jTIDWpf81Sfiwk3T845V0yJJGxjawjkQZmIWVgPW/qY/dMSv0o08FRWJ/zsg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@embedded-postgres/windows-x64": {
+      "version": "16.14.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@embedded-postgres/windows-x64/-/windows-x64-16.14.0-beta.17.tgz",
+      "integrity": "sha512-Wn4nuAT1H7SIJuLWPs+C1aSdZKpbTloCr0Xaozdfg956lUVvv3iHv6K8Lsc+xmtt1qQpTno3PJLqAgzJ/lg60Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/@emnapi/core": {
@@ -3527,6 +3672,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3541,6 +3689,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3611,9 +3762,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3628,9 +3776,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4293,6 +4438,16 @@
       "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/async-exit-hook": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/async-exit-hook/-/async-exit-hook-2.0.1.tgz",
+      "integrity": "sha512-NW2cX8m1Q7KPA7a5M2ULQeZ2wR5qI5PAbw5L0UOMxdioVk9PMZ0h1TmyZEkPYrCvYjDlFICusOu1dlEKAAeXBw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
@@ -5449,6 +5604,30 @@
       "integrity": "sha512-cUVA7/RvbFTEuw/i3obUwDTRIXojaxkResf+ibByPFxjc6XK3VNtcQXV0NSbAlJ0FMjcJGgftVVB4Qo184EXvA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/embedded-postgres": {
+      "version": "16.14.0-beta.17",
+      "resolved": "https://registry.npmjs.org/embedded-postgres/-/embedded-postgres-16.14.0-beta.17.tgz",
+      "integrity": "sha512-nMz+FokxBkEDcK3XUxTR0Jo2SGBj5mgLm2/wmGV6iIu0+3z44pNCCr6PCdu+dS/JxTCjVVV4tYmgRf7jamJS7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "async-exit-hook": "^2.0.1",
+        "pg": "^8.7.3"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@embedded-postgres/darwin-arm64": "^16.14.0-beta.17",
+        "@embedded-postgres/darwin-x64": "^16.14.0-beta.17",
+        "@embedded-postgres/linux-arm": "^16.14.0-beta.17",
+        "@embedded-postgres/linux-arm64": "^16.14.0-beta.17",
+        "@embedded-postgres/linux-ia32": "^16.14.0-beta.17",
+        "@embedded-postgres/linux-ppc64": "^16.14.0-beta.17",
+        "@embedded-postgres/linux-x64": "^16.14.0-beta.17",
+        "@embedded-postgres/windows-x64": "^16.14.0-beta.17"
+      }
     },
     "node_modules/emittery": {
       "version": "0.13.1",

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "@types/uuid": "^10.0.0",
     "@typescript-eslint/eslint-plugin": "^8.53.0",
     "@typescript-eslint/parser": "^8.53.0",
+    "embedded-postgres": "^16.14.0-beta.17",
     "eslint": "^9.18.0",
     "eslint-config-prettier": "^10.0.1",
     "eslint-plugin-prettier": "^5.2.2",

--- a/src/database/migrations.integration.spec.ts
+++ b/src/database/migrations.integration.spec.ts
@@ -1,0 +1,39 @@
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+import { AccountStatus } from '../modules/accounts/enums/account-status.enum.js';
+
+const execFileAsync = promisify(execFile);
+
+type MigrationCheckResult = {
+  enumValues: string[];
+  executedMigrationNames: string[];
+  foreignKeyColumns: string[][];
+  foreignKeyRejected: boolean;
+  schemaInSync: boolean;
+};
+
+describe('Database migrations integration', () => {
+  jest.setTimeout(180_000);
+
+  let result: MigrationCheckResult;
+
+  beforeAll(async () => {
+    const { stdout } = await execFileAsync(
+      process.execPath,
+      ['--loader', 'ts-node/esm', './test/migrations.integration.runner.ts'],
+      {
+        cwd: process.cwd(),
+      },
+    );
+
+    result = JSON.parse(stdout) as MigrationCheckResult;
+  });
+
+  it('applies every migration, matches entity metadata, and enforces foreign keys', () => {
+    expect(result.executedMigrationNames).toHaveLength(5);
+    expect(result.schemaInSync).toBe(true);
+    expect(result.enumValues).toEqual(Object.values(AccountStatus));
+    expect(result.foreignKeyColumns).toContainEqual(['accountId']);
+    expect(result.foreignKeyRejected).toBe(true);
+  });
+});

--- a/src/database/migrations/1718100001000-CreateClaimsTable.ts
+++ b/src/database/migrations/1718100001000-CreateClaimsTable.ts
@@ -25,6 +25,10 @@ export class CreateClaimsTable1718100001000 implements MigrationInterface {
     await queryRunner.query(
       `CREATE INDEX "IDX_claims_accountId" ON "claims" ("accountId")`,
     );
+    await queryRunner.query(`
+      COMMENT ON COLUMN "claims"."sweepTxHash" IS
+      'Stellar transaction hash of the sweep. Always a 64-character hex string — never a placeholder value. Enforced by TransactionHashValidator before record creation.'
+    `);
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {

--- a/src/modules/accounts/entities/account.entity.ts
+++ b/src/modules/accounts/entities/account.entity.ts
@@ -14,7 +14,7 @@ export class Account {
   id: string;
 
   @Column({ type: 'varchar', length: 56, unique: true })
-  @Index()
+  @Index('IDX_accounts_publicKey')
   publicKey: string;
 
   @Column({ type: 'text' })
@@ -32,20 +32,21 @@ export class Account {
   @Column({
     type: 'enum',
     enum: AccountStatus,
+    enumName: 'account_status_enum',
     default: AccountStatus.PENDING_PAYMENT,
   })
-  @Index()
+  @Index('IDX_accounts_status')
   status: AccountStatus;
 
   @Column({ type: 'varchar', length: 64, nullable: true })
-  @Index()
+  @Index('IDX_accounts_claimTokenHash')
   claimTokenHash: string;
 
   @Column({ type: 'varchar', length: 56, nullable: true })
   destinationAddress: string;
 
   @Column({ type: 'timestamp' })
-  @Index()
+  @Index('IDX_accounts_expiresAt')
   expiresAt: Date; // Scheduled expiry time - set on creation, used by the expiry scheduler
 
   @CreateDateColumn()

--- a/src/modules/claims/entities/claim.entity.ts
+++ b/src/modules/claims/entities/claim.entity.ts
@@ -17,11 +17,14 @@ export class Claim {
   id: string;
 
   @Column({ type: 'uuid' })
-  @Index()
+  @Index('IDX_claims_accountId')
   accountId: string;
 
   @ManyToOne(() => Account, { eager: false, onDelete: 'CASCADE' })
-  @JoinColumn({ name: 'accountId' })
+  @JoinColumn({
+    name: 'accountId',
+    foreignKeyConstraintName: 'FK_claims_accountId',
+  })
   account: Account;
 
   @Column({ type: 'varchar', length: 56 })

--- a/src/modules/webhooks/entities/webhook.entity.ts
+++ b/src/modules/webhooks/entities/webhook.entity.ts
@@ -22,7 +22,7 @@ export class Webhook {
   events: string[];
 
   @Column({ type: 'boolean', default: true })
-  @Index()
+  @Index('IDX_webhooks_isActive')
   isActive: boolean;
 
   @Column({ type: 'varchar', length: 255, nullable: true })

--- a/test/migrations.integration.runner.ts
+++ b/test/migrations.integration.runner.ts
@@ -1,0 +1,179 @@
+import { randomUUID } from 'crypto';
+import { mkdtemp, rm } from 'fs/promises';
+import * as net from 'net';
+import * as os from 'os';
+import * as path from 'path';
+import EmbeddedPostgres from 'embedded-postgres';
+import { DataSource } from 'typeorm';
+import { Account } from '../src/modules/accounts/entities/account.entity.js';
+import { AccountStatus } from '../src/modules/accounts/enums/account-status.enum.js';
+import { Claim } from '../src/modules/claims/entities/claim.entity.js';
+import { Webhook } from '../src/modules/webhooks/entities/webhook.entity.js';
+import { CreateAccountsTable1718100000000 } from '../src/database/migrations/1718100000000-CreateAccountsTable.js';
+import { CreateClaimsTable1718100001000 } from '../src/database/migrations/1718100001000-CreateClaimsTable.js';
+import { AddInitializingToAccountStatus1718100002000 } from '../src/database/migrations/1718100002000-AddInitializingToAccountStatus.js';
+import { CreateWebhooksTable1718100003000 } from '../src/database/migrations/1718100003000-CreateWebhooksTable.js';
+import { AddClaimingToAccountStatus1718100004000 } from '../src/database/migrations/1718100004000-AddClaimingToAccountStatus.js';
+
+const postgresUser = 'postgres';
+const postgresPassword = 'postgres';
+const postgresDatabase = 'bridgelet_test';
+
+const migrations = [
+  CreateAccountsTable1718100000000,
+  CreateClaimsTable1718100001000,
+  AddInitializingToAccountStatus1718100002000,
+  CreateWebhooksTable1718100003000,
+  AddClaimingToAccountStatus1718100004000,
+];
+
+type SqlInMemoryLog = {
+  upQueries: unknown[];
+};
+
+async function getFreePort(): Promise<number> {
+  return await new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.unref();
+    server.on('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+
+      if (address == null || typeof address === 'string') {
+        reject(new Error('Unable to allocate a local port for migration checks.'));
+        return;
+      }
+
+      const { port } = address;
+      server.close((error) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+
+        resolve(port);
+      });
+    });
+  });
+}
+
+async function main(): Promise<void> {
+  const port = await getFreePort();
+  const postgresDataDir = await mkdtemp(
+    path.join(os.tmpdir(), 'bridgelet-migrations-'),
+  );
+  const postgresServer = new EmbeddedPostgres({
+    databaseDir: postgresDataDir,
+    port,
+    user: postgresUser,
+    password: postgresPassword,
+    persistent: false,
+    onLog: () => undefined,
+    onError: () => undefined,
+  });
+
+  let dataSource: DataSource | null = null;
+
+  try {
+    await postgresServer.initialise();
+    await postgresServer.start();
+    await postgresServer.createDatabase(postgresDatabase);
+
+    dataSource = new DataSource({
+      type: 'postgres',
+      host: '127.0.0.1',
+      port,
+      username: postgresUser,
+      password: postgresPassword,
+      database: postgresDatabase,
+      entities: [Account, Claim, Webhook],
+      migrations,
+      migrationsTransactionMode: 'each',
+      synchronize: false,
+    });
+
+    await dataSource.initialize();
+    await dataSource.query('CREATE EXTENSION IF NOT EXISTS pgcrypto');
+
+    const executedMigrations = await dataSource.runMigrations();
+    const schemaLog = (await (
+      dataSource.driver.createSchemaBuilder() as unknown as {
+        log: () => Promise<SqlInMemoryLog>;
+      }
+    ).log()) as SqlInMemoryLog;
+
+    const enumRows: Array<{ enumlabel: string }> = await dataSource.query(`
+      SELECT e.enumlabel
+      FROM pg_type t
+      INNER JOIN pg_enum e ON e.enumtypid = t.oid
+      INNER JOIN pg_namespace n ON n.oid = t.typnamespace
+      WHERE n.nspname = 'public'
+        AND t.typname = 'account_status_enum'
+      ORDER BY e.enumsortorder
+    `);
+
+    const queryRunner = dataSource.createQueryRunner();
+    let foreignKeyColumns: string[][] = [];
+    let foreignKeyRejected = false;
+
+    try {
+      const claimsTable = await queryRunner.getTable('claims');
+      foreignKeyColumns =
+        claimsTable?.foreignKeys.map((foreignKey) => foreignKey.columnNames) ??
+        [];
+    } finally {
+      await queryRunner.release();
+    }
+
+    try {
+      await dataSource.query(
+        `
+          INSERT INTO "claims" (
+            "accountId",
+            "destinationAddress",
+            "sweepTxHash",
+            "amountSwept",
+            "asset",
+            "claimedAt"
+          )
+          VALUES ($1, $2, $3, $4, $5, NOW())
+        `,
+        [
+          randomUUID(),
+          'GBRPYHIL2C6LYK7D5QXHZJ5M5XT4QSLVQOQ43I6QJVU4YQ5N3B7V4XYZ',
+          'a'.repeat(64),
+          '1.0000000',
+          'USDC',
+        ],
+      );
+    } catch (error) {
+      foreignKeyRejected =
+        typeof error === 'object' &&
+        error !== null &&
+        'code' in error &&
+        error.code === '23503';
+    }
+
+    process.stdout.write(
+      JSON.stringify({
+        enumValues: enumRows.map(({ enumlabel }) => enumlabel),
+        executedMigrationNames: executedMigrations.map(({ name }) => name),
+        foreignKeyColumns,
+        foreignKeyRejected,
+        schemaInSync: schemaLog.upQueries.length === 0,
+      }),
+    );
+  } finally {
+    if (dataSource?.isInitialized) {
+      await dataSource.destroy();
+    }
+
+    await postgresServer.stop();
+    await rm(postgresDataDir, { recursive: true, force: true });
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/test/migrations.integration.runner.ts
+++ b/test/migrations.integration.runner.ts
@@ -40,7 +40,9 @@ async function getFreePort(): Promise<number> {
       const address = server.address();
 
       if (address == null || typeof address === 'string') {
-        reject(new Error('Unable to allocate a local port for migration checks.'));
+        reject(
+          new Error('Unable to allocate a local port for migration checks.'),
+        );
         return;
       }
 
@@ -96,11 +98,11 @@ async function main(): Promise<void> {
     await dataSource.query('CREATE EXTENSION IF NOT EXISTS pgcrypto');
 
     const executedMigrations = await dataSource.runMigrations();
-    const schemaLog = (await (
+    const schemaLog = await (
       dataSource.driver.createSchemaBuilder() as unknown as {
         log: () => Promise<SqlInMemoryLog>;
       }
-    ).log()) as SqlInMemoryLog;
+    ).log();
 
     const enumRows: Array<{ enumlabel: string }> = await dataSource.query(`
       SELECT e.enumlabel

--- a/test/migrations.integration.runner.ts
+++ b/test/migrations.integration.runner.ts
@@ -6,7 +6,6 @@ import * as path from 'path';
 import EmbeddedPostgres from 'embedded-postgres';
 import { DataSource } from 'typeorm';
 import { Account } from '../src/modules/accounts/entities/account.entity.js';
-import { AccountStatus } from '../src/modules/accounts/enums/account-status.enum.js';
 import { Claim } from '../src/modules/claims/entities/claim.entity.js';
 import { Webhook } from '../src/modules/webhooks/entities/webhook.entity.js';
 import { CreateAccountsTable1718100000000 } from '../src/database/migrations/1718100000000-CreateAccountsTable.js';
@@ -149,11 +148,9 @@ async function main(): Promise<void> {
         ],
       );
     } catch (error) {
+      const pgError = error as PgErrorLike;
       foreignKeyRejected =
-        typeof error === 'object' &&
-        error !== null &&
-        'code' in error &&
-        error.code === '23503';
+        typeof error === 'object' && error !== null && pgError.code === '23503';
     }
 
     process.stdout.write(
@@ -179,3 +176,6 @@ main().catch((error) => {
   console.error(error);
   process.exitCode = 1;
 });
+type PgErrorLike = {
+  code?: string;
+};


### PR DESCRIPTION
## Summary

Adds an integration test that provisions a fresh PostgreSQL instance, runs all current migrations, and verifies the resulting schema matches the TypeORM entity metadata.

## What Changed

- added a migration integration test that:
  - runs all current migrations on a fresh Postgres database
  - verifies the schema is in sync with TypeORM metadata
  - validates `account_status_enum` values
  - confirms the `claims.accountId -> accounts.id` foreign key is enforced
- added an embedded Postgres runner to make the test self-contained
- aligned entity metadata with the existing migration-defined enum, index, and foreign key names
- added the missing `claims.sweepTxHash` column comment to the migration
- updated README and database schema docs to reflect the current migration set and test coverage

## Verification

- `npm test -- migrations.integration.spec.ts --runInBand`
- `npm test -- --runInBand`

## Notes

- The repository currently has 5 migration files, even though the issue text references 4.
- `npm run test:cov -- --runInBand` still fails due existing repo-wide coverage gaps outside this change set:
  - statements: `70.52%`
  - branches: `51.52%`
  - functions: `68.08%`
  - lines: `70.53%`

fixes #174
