### PR TITLE
Feature: Create webhook_deliveries migration (#176)

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ cp .env.example .env
 #   1718100002000-AddInitializingToAccountStatus (adds INITIALIZING to account_status enum)
 #   1718100003000-CreateWebhooksTable            (webhooks table)
 #   1718100004000-AddClaimingToAccountStatus     (adds CLAIMING to account_status enum)
+#   1718100005000-CreateWebhookDeliveriesTable   (webhook delivery attempt log table)
 npm run migration:run
 
 # Start development server
@@ -142,7 +143,7 @@ npm run test:cov
 
 Coverage reports are generated in the `coverage/` directory. The build will fail if any metric (branches, functions, lines, statements) falls below 80%.
 
-The repository also includes an embedded-Postgres integration test in `src/database/migrations.integration.spec.ts` that starts a fresh PostgreSQL instance, runs all current migrations, verifies the resulting schema matches the TypeORM entities, checks the `account_status_enum` values, and confirms the `claims.accountId -> accounts.id` foreign key is enforced.
+The repository also includes an embedded-Postgres integration test in `src/database/migrations.integration.spec.ts` that starts a fresh PostgreSQL instance, runs all current migrations, verifies the resulting schema matches the TypeORM entities, checks the `account_status_enum` values, and confirms the `claims.accountId -> accounts.id` and `webhook_deliveries.subscription_id -> webhooks.id` foreign keys are enforced.
 
 To check coverage for a specific file:
 

--- a/docs/database-schema.md
+++ b/docs/database-schema.md
@@ -6,7 +6,8 @@ The current schema is created entirely through the migrations in `src/database/m
 
 - `accounts`: stores ephemeral account lifecycle data, including encrypted secret material, funding metadata, expiry timestamps, and optional claim metadata.
 - `claims`: stores completed claim records and references `accounts.id` through a cascading foreign key on `accountId`.
-- `webhooks`: stores outbound webhook subscriptions and delivery metadata.
+- `webhooks`: stores outbound webhook subscriptions.
+- `webhook_deliveries`: stores per-delivery webhook attempts, including the subscribed webhook reference (`subscription_id`), event type, payload hash, retry count, last response details, delivery timestamp, and creation timestamp. It references `webhooks.id` with `ON DELETE CASCADE` and has a composite index on (`subscription_id`, `created_at`).
 
 ## Account Status Enum
 
@@ -16,4 +17,4 @@ The current schema is created entirely through the migrations in `src/database/m
 
 ## Migration Verification
 
-`src/database/migrations.integration.spec.ts` provisions a fresh embedded PostgreSQL database, applies every migration, verifies the resulting schema matches the TypeORM entity metadata, and checks that the `claims.accountId` foreign key is enforced.
+`src/database/migrations.integration.spec.ts` provisions a fresh embedded PostgreSQL database, applies every migration, verifies the resulting schema matches the TypeORM entity metadata, and checks that the `claims.accountId` and `webhook_deliveries.subscription_id` foreign keys are enforced.

--- a/src/database/migrations.integration.spec.ts
+++ b/src/database/migrations.integration.spec.ts
@@ -19,11 +19,13 @@ describe('Database migrations integration', () => {
   jest.setTimeout(180_000);
 
   let result: MigrationCheckResult;
+  const tsNodeRegisterImport =
+    'data:text/javascript,import { register } from "node:module"; import { pathToFileURL } from "node:url"; register("ts-node/esm/transpile-only", pathToFileURL("./"));';
 
   beforeAll(async () => {
     const { stdout } = await execFileAsync(
       process.execPath,
-      ['--loader', 'ts-node/esm', './test/migrations.integration.runner.ts'],
+      ['--import', tsNodeRegisterImport, './test/migrations.integration.runner.ts'],
       {
         cwd: process.cwd(),
       },

--- a/src/database/migrations.integration.spec.ts
+++ b/src/database/migrations.integration.spec.ts
@@ -38,7 +38,9 @@ describe('Database migrations integration', () => {
     expect(result.enumValues).toEqual(Object.values(AccountStatus));
     expect(result.foreignKeyColumns).toContainEqual(['accountId']);
     expect(result.foreignKeyRejected).toBe(true);
-    expect(result.deliveryForeignKeyColumns).toContainEqual(['subscription_id']);
+    expect(result.deliveryForeignKeyColumns).toContainEqual([
+      'subscription_id',
+    ]);
     expect(result.deliveryForeignKeyRejected).toBe(true);
     expect(result.deliveryIndexes).toContainEqual([
       'subscription_id',

--- a/src/database/migrations.integration.spec.ts
+++ b/src/database/migrations.integration.spec.ts
@@ -9,6 +9,9 @@ type MigrationCheckResult = {
   executedMigrationNames: string[];
   foreignKeyColumns: string[][];
   foreignKeyRejected: boolean;
+  deliveryForeignKeyColumns: string[][];
+  deliveryForeignKeyRejected: boolean;
+  deliveryIndexes: string[][];
   schemaInSync: boolean;
 };
 
@@ -30,10 +33,16 @@ describe('Database migrations integration', () => {
   });
 
   it('applies every migration, matches entity metadata, and enforces foreign keys', () => {
-    expect(result.executedMigrationNames).toHaveLength(5);
+    expect(result.executedMigrationNames).toHaveLength(6);
     expect(result.schemaInSync).toBe(true);
     expect(result.enumValues).toEqual(Object.values(AccountStatus));
     expect(result.foreignKeyColumns).toContainEqual(['accountId']);
     expect(result.foreignKeyRejected).toBe(true);
+    expect(result.deliveryForeignKeyColumns).toContainEqual(['subscription_id']);
+    expect(result.deliveryForeignKeyRejected).toBe(true);
+    expect(result.deliveryIndexes).toContainEqual([
+      'subscription_id',
+      'created_at',
+    ]);
   });
 });

--- a/src/database/migrations.integration.spec.ts
+++ b/src/database/migrations.integration.spec.ts
@@ -25,7 +25,11 @@ describe('Database migrations integration', () => {
   beforeAll(async () => {
     const { stdout } = await execFileAsync(
       process.execPath,
-      ['--import', tsNodeRegisterImport, './test/migrations.integration.runner.ts'],
+      [
+        '--import',
+        tsNodeRegisterImport,
+        './test/migrations.integration.runner.ts',
+      ],
       {
         cwd: process.cwd(),
       },

--- a/src/database/migrations/1718100005000-CreateWebhookDeliveriesTable.ts
+++ b/src/database/migrations/1718100005000-CreateWebhookDeliveriesTable.ts
@@ -1,8 +1,6 @@
 import { MigrationInterface, QueryRunner } from 'typeorm';
 
-export class CreateWebhookDeliveriesTable1718100005000
-  implements MigrationInterface
-{
+export class CreateWebhookDeliveriesTable1718100005000 implements MigrationInterface {
   name = 'CreateWebhookDeliveriesTable1718100005000';
 
   public async up(queryRunner: QueryRunner): Promise<void> {

--- a/src/database/migrations/1718100005000-CreateWebhookDeliveriesTable.ts
+++ b/src/database/migrations/1718100005000-CreateWebhookDeliveriesTable.ts
@@ -1,0 +1,40 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CreateWebhookDeliveriesTable1718100005000
+  implements MigrationInterface
+{
+  name = 'CreateWebhookDeliveriesTable1718100005000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE "webhook_deliveries" (
+        "id"                  uuid                   NOT NULL DEFAULT gen_random_uuid(),
+        "subscription_id"     uuid                   NOT NULL,
+        "event_type"          character varying(255) NOT NULL,
+        "payload_hash"        character varying(128) NOT NULL,
+        "attempt_count"       integer                NOT NULL DEFAULT 1,
+        "last_response_code"  integer,
+        "last_response_body"  character varying(2048),
+        "delivered_at"        TIMESTAMP,
+        "created_at"          TIMESTAMP              NOT NULL DEFAULT now(),
+        CONSTRAINT "PK_webhook_deliveries" PRIMARY KEY ("id"),
+        CONSTRAINT "FK_webhook_deliveries_subscription_id"
+          FOREIGN KEY ("subscription_id")
+          REFERENCES "webhooks"("id")
+          ON DELETE CASCADE
+      )
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX "IDX_webhook_deliveries_subscription_id_created_at"
+      ON "webhook_deliveries" ("subscription_id", "created_at")
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      DROP INDEX "IDX_webhook_deliveries_subscription_id_created_at"
+    `);
+    await queryRunner.query(`DROP TABLE "webhook_deliveries"`);
+  }
+}

--- a/src/modules/webhooks/entities/webhook-delivery.entity.ts
+++ b/src/modules/webhooks/entities/webhook-delivery.entity.ts
@@ -1,0 +1,57 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+import { Webhook } from './webhook.entity.js';
+
+@Entity('webhook_deliveries')
+@Index('IDX_webhook_deliveries_subscription_id_created_at', [
+  'subscriptionId',
+  'createdAt',
+])
+export class WebhookDelivery {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ name: 'subscription_id', type: 'uuid' })
+  subscriptionId: string;
+
+  @ManyToOne(() => Webhook, { onDelete: 'CASCADE' })
+  @JoinColumn({
+    name: 'subscription_id',
+    referencedColumnName: 'id',
+    foreignKeyConstraintName: 'FK_webhook_deliveries_subscription_id',
+  })
+  subscription: Webhook;
+
+  @Column({ name: 'event_type', type: 'varchar', length: 255 })
+  eventType: string;
+
+  @Column({ name: 'payload_hash', type: 'varchar', length: 128 })
+  payloadHash: string;
+
+  @Column({ name: 'attempt_count', type: 'integer', default: 1 })
+  attemptCount: number;
+
+  @Column({ name: 'last_response_code', type: 'integer', nullable: true })
+  lastResponseCode: number | null;
+
+  @Column({
+    name: 'last_response_body',
+    type: 'varchar',
+    length: 2048,
+    nullable: true,
+  })
+  lastResponseBody: string | null;
+
+  @Column({ name: 'delivered_at', type: 'timestamp', nullable: true })
+  deliveredAt: Date | null;
+
+  @CreateDateColumn({ name: 'created_at', type: 'timestamp' })
+  createdAt: Date;
+}

--- a/test/migrations.integration.runner.ts
+++ b/test/migrations.integration.runner.ts
@@ -8,12 +8,14 @@ import { DataSource } from 'typeorm';
 import { Account } from '../src/modules/accounts/entities/account.entity.js';
 import { AccountStatus } from '../src/modules/accounts/enums/account-status.enum.js';
 import { Claim } from '../src/modules/claims/entities/claim.entity.js';
+import { WebhookDelivery } from '../src/modules/webhooks/entities/webhook-delivery.entity.js';
 import { Webhook } from '../src/modules/webhooks/entities/webhook.entity.js';
 import { CreateAccountsTable1718100000000 } from '../src/database/migrations/1718100000000-CreateAccountsTable.js';
 import { CreateClaimsTable1718100001000 } from '../src/database/migrations/1718100001000-CreateClaimsTable.js';
 import { AddInitializingToAccountStatus1718100002000 } from '../src/database/migrations/1718100002000-AddInitializingToAccountStatus.js';
 import { CreateWebhooksTable1718100003000 } from '../src/database/migrations/1718100003000-CreateWebhooksTable.js';
 import { AddClaimingToAccountStatus1718100004000 } from '../src/database/migrations/1718100004000-AddClaimingToAccountStatus.js';
+import { CreateWebhookDeliveriesTable1718100005000 } from '../src/database/migrations/1718100005000-CreateWebhookDeliveriesTable.js';
 
 const postgresUser = 'postgres';
 const postgresPassword = 'postgres';
@@ -25,6 +27,7 @@ const migrations = [
   AddInitializingToAccountStatus1718100002000,
   CreateWebhooksTable1718100003000,
   AddClaimingToAccountStatus1718100004000,
+  CreateWebhookDeliveriesTable1718100005000,
 ];
 
 type SqlInMemoryLog = {
@@ -86,7 +89,7 @@ async function main(): Promise<void> {
       username: postgresUser,
       password: postgresPassword,
       database: postgresDatabase,
-      entities: [Account, Claim, Webhook],
+      entities: [Account, Claim, Webhook, WebhookDelivery],
       migrations,
       migrationsTransactionMode: 'each',
       synchronize: false,
@@ -115,12 +118,24 @@ async function main(): Promise<void> {
     const queryRunner = dataSource.createQueryRunner();
     let foreignKeyColumns: string[][] = [];
     let foreignKeyRejected = false;
+    let deliveryForeignKeyColumns: string[][] = [];
+    let deliveryForeignKeyRejected = false;
+    let deliveryIndexes: string[][] = [];
 
     try {
       const claimsTable = await queryRunner.getTable('claims');
       foreignKeyColumns =
         claimsTable?.foreignKeys.map((foreignKey) => foreignKey.columnNames) ??
         [];
+
+      const webhookDeliveriesTable =
+        await queryRunner.getTable('webhook_deliveries');
+      deliveryForeignKeyColumns =
+        webhookDeliveriesTable?.foreignKeys.map(
+          (foreignKey) => foreignKey.columnNames,
+        ) ?? [];
+      deliveryIndexes =
+        webhookDeliveriesTable?.indices.map((index) => index.columnNames) ?? [];
     } finally {
       await queryRunner.release();
     }
@@ -154,12 +169,35 @@ async function main(): Promise<void> {
         error.code === '23503';
     }
 
+    try {
+      await dataSource.query(
+        `
+          INSERT INTO "webhook_deliveries" (
+            "subscription_id",
+            "event_type",
+            "payload_hash"
+          )
+          VALUES ($1, $2, $3)
+        `,
+        [randomUUID(), 'account.created', 'b'.repeat(64)],
+      );
+    } catch (error) {
+      deliveryForeignKeyRejected =
+        typeof error === 'object' &&
+        error !== null &&
+        'code' in error &&
+        error.code === '23503';
+    }
+
     process.stdout.write(
       JSON.stringify({
         enumValues: enumRows.map(({ enumlabel }) => enumlabel),
         executedMigrationNames: executedMigrations.map(({ name }) => name),
         foreignKeyColumns,
         foreignKeyRejected,
+        deliveryForeignKeyColumns,
+        deliveryForeignKeyRejected,
+        deliveryIndexes,
         schemaInSync: schemaLog.upQueries.length === 0,
       }),
     );

--- a/test/migrations.integration.runner.ts
+++ b/test/migrations.integration.runner.ts
@@ -43,7 +43,9 @@ async function getFreePort(): Promise<number> {
       const address = server.address();
 
       if (address == null || typeof address === 'string') {
-        reject(new Error('Unable to allocate a local port for migration checks.'));
+        reject(
+          new Error('Unable to allocate a local port for migration checks.'),
+        );
         return;
       }
 
@@ -99,11 +101,11 @@ async function main(): Promise<void> {
     await dataSource.query('CREATE EXTENSION IF NOT EXISTS pgcrypto');
 
     const executedMigrations = await dataSource.runMigrations();
-    const schemaLog = (await (
+    const schemaLog = await (
       dataSource.driver.createSchemaBuilder() as unknown as {
         log: () => Promise<SqlInMemoryLog>;
       }
-    ).log()) as SqlInMemoryLog;
+    ).log();
 
     const enumRows: Array<{ enumlabel: string }> = await dataSource.query(`
       SELECT e.enumlabel

--- a/test/migrations.integration.runner.ts
+++ b/test/migrations.integration.runner.ts
@@ -6,7 +6,6 @@ import * as path from 'path';
 import EmbeddedPostgres from 'embedded-postgres';
 import { DataSource } from 'typeorm';
 import { Account } from '../src/modules/accounts/entities/account.entity.js';
-import { AccountStatus } from '../src/modules/accounts/enums/account-status.enum.js';
 import { Claim } from '../src/modules/claims/entities/claim.entity.js';
 import { WebhookDelivery } from '../src/modules/webhooks/entities/webhook-delivery.entity.js';
 import { Webhook } from '../src/modules/webhooks/entities/webhook.entity.js';
@@ -32,6 +31,10 @@ const migrations = [
 
 type SqlInMemoryLog = {
   upQueries: unknown[];
+};
+
+type PgErrorLike = {
+  code?: string;
 };
 
 async function getFreePort(): Promise<number> {
@@ -164,11 +167,9 @@ async function main(): Promise<void> {
         ],
       );
     } catch (error) {
+      const pgError = error as PgErrorLike;
       foreignKeyRejected =
-        typeof error === 'object' &&
-        error !== null &&
-        'code' in error &&
-        error.code === '23503';
+        typeof error === 'object' && error !== null && pgError.code === '23503';
     }
 
     try {
@@ -184,11 +185,9 @@ async function main(): Promise<void> {
         [randomUUID(), 'account.created', 'b'.repeat(64)],
       );
     } catch (error) {
+      const pgError = error as PgErrorLike;
       deliveryForeignKeyRejected =
-        typeof error === 'object' &&
-        error !== null &&
-        'code' in error &&
-        error.code === '23503';
+        typeof error === 'object' && error !== null && pgError.code === '23503';
     }
 
     process.stdout.write(

--- a/test/migrations.integration.runner.ts
+++ b/test/migrations.integration.runner.ts
@@ -216,6 +216,3 @@ main().catch((error) => {
   console.error(error);
   process.exitCode = 1;
 });
-type PgErrorLike = {
-  code?: string;
-};


### PR DESCRIPTION
## Summary

Adds the `webhook_deliveries` database migration for tracking webhook delivery attempts.

## Changes

- create `webhook_deliveries` table
- add foreign key from `webhook_deliveries.subscription_id` to `webhooks.id`
- add composite index on `subscription_id` + `created_at`
- add matching TypeORM entity for schema sync validation
- extend migration integration tests to verify:
  - all migrations apply cleanly
  - the new foreign key is enforced
  - the composite index exists
- update database documentation

## Table schema

The new table includes:

- `id`
- `subscription_id`
- `event_type`
- `payload_hash`
- `attempt_count`
- `last_response_code`
- `last_response_body`
- `delivered_at`
- `created_at`

## Verification

- `npm run build` 
- `npm test -- src/database/migrations.integration.spec.ts` 

fixes #176 