### PR TITLE
feature: audit log entry for every claim attempt (#35)

### DIFF
--- a/src/database/migrations/1718100005000-CreateClaimAuditLog.ts
+++ b/src/database/migrations/1718100005000-CreateClaimAuditLog.ts
@@ -1,0 +1,32 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CreateClaimAuditLog1718100005000 implements MigrationInterface {
+  name = 'CreateClaimAuditLog1718100005000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE "claim_audit_log" (
+        "id"              uuid                   NOT NULL DEFAULT gen_random_uuid(),
+        "accountId"       uuid                   NOT NULL,
+        "destinationHash" character varying(64)  NOT NULL,
+        "ipHash"          character varying(64),
+        "outcome"         character varying(10)  NOT NULL,
+        "failureReason"   text,
+        "attemptedAt"     TIMESTAMP              NOT NULL DEFAULT now(),
+        CONSTRAINT "PK_claim_audit_log" PRIMARY KEY ("id")
+      )
+    `);
+    await queryRunner.query(
+      `CREATE INDEX "IDX_claim_audit_log_accountId" ON "claim_audit_log" ("accountId")`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_claim_audit_log_attemptedAt" ON "claim_audit_log" ("attemptedAt")`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX "IDX_claim_audit_log_attemptedAt"`);
+    await queryRunner.query(`DROP INDEX "IDX_claim_audit_log_accountId"`);
+    await queryRunner.query(`DROP TABLE "claim_audit_log"`);
+  }
+}

--- a/src/modules/claims/claims.module.ts
+++ b/src/modules/claims/claims.module.ts
@@ -4,10 +4,12 @@ import { ClaimsController } from './claims.controller.js';
 import { ClaimsService } from './claims.service.js';
 import { Claim } from './entities/claim.entity.js';
 import { Account } from '../accounts/entities/account.entity.js';
+import { ClaimAuditLog } from './entities/claim-audit-log.entity.js';
 
 import { ClaimLookupProvider } from './providers/claim-lookup.provider.js';
 import { TokenVerificationProvider } from './providers/token-verification.provider.js';
 import { ClaimRedemptionProvider } from './providers/claim-redemption.provider.js';
+import { ClaimAuditProvider } from './providers/claim-audit.provider.js';
 import { SweepsModule } from '../sweeps/sweeps.module.js';
 import { WebhooksModule } from '../webhooks/webhooks.module.js';
 import { makeCounterProvider } from '@willsoto/nestjs-prometheus';
@@ -19,7 +21,7 @@ const claimRedemptionCounter = makeCounterProvider({
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([Claim, Account]),
+    TypeOrmModule.forFeature([Claim, Account, ClaimAuditLog]),
     SweepsModule,
     WebhooksModule,
   ],
@@ -30,6 +32,7 @@ const claimRedemptionCounter = makeCounterProvider({
     ClaimRedemptionProvider,
     TokenVerificationProvider,
     claimRedemptionCounter,
+    ClaimAuditProvider,
   ],
   exports: [ClaimsService],
 })

--- a/src/modules/claims/entities/claim-audit-log.entity.ts
+++ b/src/modules/claims/entities/claim-audit-log.entity.ts
@@ -1,0 +1,37 @@
+import {
+  Entity,
+  Column,
+  PrimaryGeneratedColumn,
+  CreateDateColumn,
+  Index,
+} from 'typeorm';
+
+export type ClaimOutcome = 'success' | 'failure';
+
+@Entity('claim_audit_log')
+@Index(['accountId'])
+@Index(['attemptedAt'])
+export class ClaimAuditLog {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'uuid' })
+  accountId: string;
+
+  /** SHA-256 of the destination address — never stored in plain text */
+  @Column({ type: 'varchar', length: 64 })
+  destinationHash: string;
+
+  /** SHA-256 of the requester IP — never stored in plain text */
+  @Column({ type: 'varchar', length: 64, nullable: true })
+  ipHash: string | null;
+
+  @Column({ type: 'varchar', length: 10 })
+  outcome: ClaimOutcome;
+
+  @Column({ type: 'text', nullable: true })
+  failureReason: string | null;
+
+  @CreateDateColumn()
+  attemptedAt: Date;
+}

--- a/src/modules/claims/providers/claim-audit.provider.spec.ts
+++ b/src/modules/claims/providers/claim-audit.provider.spec.ts
@@ -43,7 +43,7 @@ describe('ClaimAuditProvider', () => {
         outcome: 'success',
       });
 
-      const saved = repo.create.mock.calls[0][0] as any;
+      const saved = repo.create.mock.calls[0][0] as Partial<ClaimAuditLog>;
       expect(saved.destinationHash).toBe(sha256(DESTINATION));
       expect(JSON.stringify(saved)).not.toContain(DESTINATION);
     });
@@ -56,7 +56,7 @@ describe('ClaimAuditProvider', () => {
         outcome: 'success',
       });
 
-      const saved = repo.create.mock.calls[0][0] as any;
+      const saved = repo.create.mock.calls[0][0] as Partial<ClaimAuditLog>;
       expect(saved.ipHash).toBe(sha256(IP));
       expect(JSON.stringify(saved)).not.toContain(IP);
     });
@@ -68,7 +68,7 @@ describe('ClaimAuditProvider', () => {
         outcome: 'success',
       });
 
-      const saved = repo.create.mock.calls[0][0] as any;
+      const saved = repo.create.mock.calls[0][0] as Partial<ClaimAuditLog>;
       expect(saved.ipHash).toBeNull();
     });
 
@@ -79,7 +79,7 @@ describe('ClaimAuditProvider', () => {
         outcome: 'success',
       });
 
-      const saved = repo.create.mock.calls[0][0] as any;
+      const saved = repo.create.mock.calls[0][0] as Partial<ClaimAuditLog>;
       expect(saved.outcome).toBe('success');
     });
 
@@ -102,7 +102,7 @@ describe('ClaimAuditProvider', () => {
         failureReason: 'Token expired',
       });
 
-      const saved = repo.create.mock.calls[0][0] as any;
+      const saved = repo.create.mock.calls[0][0] as Partial<ClaimAuditLog>;
       expect(saved.outcome).toBe('failure');
       expect(saved.failureReason).toBe('Token expired');
     });
@@ -114,7 +114,7 @@ describe('ClaimAuditProvider', () => {
         outcome: 'failure',
       });
 
-      const saved = repo.create.mock.calls[0][0] as any;
+      const saved = repo.create.mock.calls[0][0] as Partial<ClaimAuditLog>;
       expect(saved.failureReason).toBeNull();
     });
   });

--- a/src/modules/claims/providers/claim-audit.provider.spec.ts
+++ b/src/modules/claims/providers/claim-audit.provider.spec.ts
@@ -1,0 +1,135 @@
+import { jest } from '@jest/globals';
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import * as crypto from 'crypto';
+import { ClaimAuditProvider } from './claim-audit.provider.js';
+import { ClaimAuditLog } from '../entities/claim-audit-log.entity.js';
+
+const ACCOUNT_ID = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+const DESTINATION = 'GBULQKZ7SA56UKRI6LX2IB6XH3GJW2L34BMTOWMQFJBAQNPSHJJNOTGN';
+const IP = '203.0.113.42';
+
+function sha256(v: string): string {
+  return crypto.createHash('sha256').update(v).digest('hex');
+}
+
+describe('ClaimAuditProvider', () => {
+  let provider: ClaimAuditProvider;
+  let repo: { create: jest.Mock; save: jest.Mock };
+
+  beforeEach(async () => {
+    repo = {
+      create: jest.fn<any>().mockImplementation((data) => data),
+      save: jest.fn<any>().mockResolvedValue(undefined),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ClaimAuditProvider,
+        { provide: getRepositoryToken(ClaimAuditLog), useValue: repo },
+      ],
+    }).compile();
+
+    provider = module.get<ClaimAuditProvider>(ClaimAuditProvider);
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  describe('record — success outcome', () => {
+    it('hashes destination and never stores plain address', async () => {
+      await provider.record({
+        accountId: ACCOUNT_ID,
+        destination: DESTINATION,
+        outcome: 'success',
+      });
+
+      const saved = repo.create.mock.calls[0][0] as any;
+      expect(saved.destinationHash).toBe(sha256(DESTINATION));
+      expect(JSON.stringify(saved)).not.toContain(DESTINATION);
+    });
+
+    it('hashes IP when provided', async () => {
+      await provider.record({
+        accountId: ACCOUNT_ID,
+        destination: DESTINATION,
+        ip: IP,
+        outcome: 'success',
+      });
+
+      const saved = repo.create.mock.calls[0][0] as any;
+      expect(saved.ipHash).toBe(sha256(IP));
+      expect(JSON.stringify(saved)).not.toContain(IP);
+    });
+
+    it('sets ipHash to null when IP is omitted', async () => {
+      await provider.record({
+        accountId: ACCOUNT_ID,
+        destination: DESTINATION,
+        outcome: 'success',
+      });
+
+      const saved = repo.create.mock.calls[0][0] as any;
+      expect(saved.ipHash).toBeNull();
+    });
+
+    it('persists outcome as success', async () => {
+      await provider.record({
+        accountId: ACCOUNT_ID,
+        destination: DESTINATION,
+        outcome: 'success',
+      });
+
+      const saved = repo.create.mock.calls[0][0] as any;
+      expect(saved.outcome).toBe('success');
+    });
+
+    it('calls repository.save()', async () => {
+      await provider.record({
+        accountId: ACCOUNT_ID,
+        destination: DESTINATION,
+        outcome: 'success',
+      });
+      expect(repo.save).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('record — failure outcome', () => {
+    it('stores outcome as failure with reason', async () => {
+      await provider.record({
+        accountId: ACCOUNT_ID,
+        destination: DESTINATION,
+        outcome: 'failure',
+        failureReason: 'Token expired',
+      });
+
+      const saved = repo.create.mock.calls[0][0] as any;
+      expect(saved.outcome).toBe('failure');
+      expect(saved.failureReason).toBe('Token expired');
+    });
+
+    it('sets failureReason to null when not provided', async () => {
+      await provider.record({
+        accountId: ACCOUNT_ID,
+        destination: DESTINATION,
+        outcome: 'failure',
+      });
+
+      const saved = repo.create.mock.calls[0][0] as any;
+      expect(saved.failureReason).toBeNull();
+    });
+  });
+
+  describe('record — resilience', () => {
+    it('does not throw when repository.save() rejects', async () => {
+      repo.save.mockRejectedValue(new Error('DB down'));
+
+      await expect(
+        provider.record({
+          accountId: ACCOUNT_ID,
+          destination: DESTINATION,
+          outcome: 'success',
+        }),
+      ).resolves.toBeUndefined();
+    });
+  });
+});

--- a/src/modules/claims/providers/claim-audit.provider.ts
+++ b/src/modules/claims/providers/claim-audit.provider.ts
@@ -1,0 +1,48 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import * as crypto from 'crypto';
+import {
+  ClaimAuditLog,
+  ClaimOutcome,
+} from '../entities/claim-audit-log.entity.js';
+
+export interface AuditClaimAttemptParams {
+  accountId: string;
+  destination: string;
+  ip?: string | null;
+  outcome: ClaimOutcome;
+  failureReason?: string | null;
+}
+
+@Injectable()
+export class ClaimAuditProvider {
+  private readonly logger = new Logger(ClaimAuditProvider.name);
+
+  constructor(
+    @InjectRepository(ClaimAuditLog)
+    private readonly auditRepository: Repository<ClaimAuditLog>,
+  ) {}
+
+  async record(params: AuditClaimAttemptParams): Promise<void> {
+    try {
+      const entry = this.auditRepository.create({
+        accountId: params.accountId,
+        destinationHash: this.hash(params.destination),
+        ipHash: params.ip ? this.hash(params.ip) : null,
+        outcome: params.outcome,
+        failureReason: params.failureReason ?? null,
+      });
+      await this.auditRepository.save(entry);
+    } catch (err) {
+      // Audit failures must never surface to the caller.
+      this.logger.error(
+        `Failed to write claim audit log for account ${params.accountId}: ${(err as Error).message}`,
+      );
+    }
+  }
+
+  private hash(value: string): string {
+    return crypto.createHash('sha256').update(value).digest('hex');
+  }
+}

--- a/src/modules/claims/providers/claim-redemption.provider.spec.ts
+++ b/src/modules/claims/providers/claim-redemption.provider.spec.ts
@@ -10,6 +10,7 @@ import { AccountStatus } from '../../accounts/enums/account-status.enum.js';
 import { ConfigService } from '@nestjs/config';
 import { SecretEncryptionUtil } from '../../../common/crypto/secret-encryption.util.js';
 import { WebhooksService } from '../../webhooks/webhooks.service.js';
+import { ClaimAuditProvider } from './claim-audit.provider.js';
 
 describe('ClaimRedemptionProvider', () => {
   let provider: ClaimRedemptionProvider;
@@ -142,6 +143,10 @@ describe('ClaimRedemptionProvider', () => {
           },
         },
         { provide: WebhooksService, useValue: mockWebhooksService },
+        {
+          provide: ClaimAuditProvider,
+          useValue: { record: jest.fn().mockResolvedValue(undefined) },
+        },
       ],
     }).compile();
 

--- a/src/modules/claims/providers/claim-redemption.provider.ts
+++ b/src/modules/claims/providers/claim-redemption.provider.ts
@@ -18,6 +18,7 @@ import { ConfigService } from '@nestjs/config';
 import { TransactionHashValidator } from '../../../common/validators/transaction-hash.validator.js';
 import { StellarAddressValidator } from '../../../common/validators/stellar-address.validator.js';
 import { WebhooksService } from '../../webhooks/webhooks.service.js';
+import { ClaimAuditProvider } from './claim-audit.provider.js';
 
 @Injectable()
 export class ClaimRedemptionProvider {
@@ -34,11 +35,13 @@ export class ClaimRedemptionProvider {
     private sweepsService: SweepsService,
     private configService: ConfigService,
     private webhooksService: WebhooksService,
+    private claimAuditProvider: ClaimAuditProvider,
   ) {}
 
   async redeemClaim(
     token: string,
     destinationAddress: string,
+    ip?: string | null,
   ): Promise<ClaimRedemptionResponseDto> {
     this.logger.log(`Redeeming claim for destination: ${destinationAddress}`);
 
@@ -160,6 +163,13 @@ export class ClaimRedemptionProvider {
 
       this.logger.log(`Claim redeemed successfully: ${claim.id}`);
 
+      await this.claimAuditProvider.record({
+        accountId: account.id,
+        destination: destinationAddress,
+        ip,
+        outcome: 'success',
+      });
+
       await this.webhooksService.triggerEvent('sweep.completed', {
         accountId: account.id,
         amount: account.amount,
@@ -190,6 +200,14 @@ export class ClaimRedemptionProvider {
         `Claim redemption failed: ${typedError.message}`,
         typedError.stack,
       );
+
+      await this.claimAuditProvider.record({
+        accountId: account.id,
+        destination: destinationAddress,
+        ip,
+        outcome: 'failure',
+        failureReason: typedError.message,
+      });
 
       await this.webhooksService.triggerEvent('sweep.failed', {
         accountId: account.id,


### PR DESCRIPTION
## Summary

Implements an immutable audit trail for every claim redemption attempt.

- New `ClaimAuditLog` entity and TypeORM migration (`claim_audit_log` table)
- `ClaimAuditProvider` records timestamp, account_id, hashed destination (SHA-256), hashed IP (SHA-256), outcome, and failure reason
- Raw addresses and IPs are **never stored** — only their SHA-256 digests
- Audit failures are swallowed internally so they never surface to the caller
- Integrated into `ClaimRedemptionProvider` on both success and failure paths
- 8 unit tests covering hashing, resilience, and all outcome permutations

**Files added/changed:**
- `src/modules/claims/entities/claim-audit-log.entity.ts`
- `src/database/migrations/1718100005000-CreateClaimAuditLog.ts`
- `src/modules/claims/providers/claim-audit.provider.ts`
- `src/modules/claims/providers/claim-audit.provider.spec.ts`
- `src/modules/claims/claims.module.ts`
- `src/modules/claims/providers/claim-redemption.provider.ts`

closes #168