### PR TITLE
feature: track and alert on account creation latency (#87)

### DIFF
--- a/src/modules/accounts/accounts.module.ts
+++ b/src/modules/accounts/accounts.module.ts
@@ -8,6 +8,7 @@ import { ConfigModule, ConfigService } from '@nestjs/config';
 import { JwtModule } from '@nestjs/jwt';
 import { PaymentMonitorProvider } from '../stellar/providers/payment-monitor-provider.js';
 import { WebhooksModule } from '../webhooks/webhooks.module.js';
+import { AccountLatencyMetricsProvider } from './providers/account-latency-metrics.provider.js';
 
 @Module({
   imports: [
@@ -26,7 +27,11 @@ import { WebhooksModule } from '../webhooks/webhooks.module.js';
     WebhooksModule,
   ],
   controllers: [AccountsController],
-  providers: [AccountsService, PaymentMonitorProvider],
+  providers: [
+    AccountsService,
+    PaymentMonitorProvider,
+    AccountLatencyMetricsProvider,
+  ],
   exports: [AccountsService, JwtModule],
 })
 

--- a/src/modules/accounts/accounts.service.ts
+++ b/src/modules/accounts/accounts.service.ts
@@ -12,6 +12,7 @@ import { AccountStatus } from './enums/account-status.enum.js';
 import { SecretEncryptionUtil } from '../../common/crypto/secret-encryption.util.js';
 import { WebhooksService } from '../webhooks/webhooks.service.js';
 import { sanitizeMetadata } from '../../common/utils/metadata-sanitizer.util.js';
+import { AccountLatencyMetricsProvider } from './providers/account-latency-metrics.provider.js';
 
 /**
  * AccountsService — Service-Level Documentation & Contributor Guidance
@@ -101,6 +102,7 @@ export class AccountsService {
     private jwtService: JwtService,
     private stellarService: StellarService,
     private webhooksService: WebhooksService,
+    private latencyMetrics: AccountLatencyMetricsProvider,
   ) {
     this.encryptionKey = this.configService.getOrThrow<string>(
       'stellar.encryptionKey',
@@ -110,6 +112,7 @@ export class AccountsService {
   public async create(
     createAccountDto: CreateAccountDto,
   ): Promise<AccountResponseDto> {
+    const startMs = Date.now();
     // Generate ephemeral keypair
     const ephemeralKeypair = this.stellarService.generateKeypair();
 
@@ -177,6 +180,8 @@ export class AccountsService {
         expiresAt: account.expiresAt,
       });
 
+      this.latencyMetrics.record(Date.now() - startMs, true);
+
       return {
         accountId: account.id,
         publicKey: account.publicKey,
@@ -189,6 +194,8 @@ export class AccountsService {
         createdAt: account.createdAt,
       };
     } catch (error: unknown) {
+      this.latencyMetrics.record(Date.now() - startMs, false);
+
       // Mark as FAILED so the record is traceable but clearly broken
       account.status = AccountStatus.FAILED;
       await this.accountsRepository.save(account);

--- a/src/modules/accounts/providers/account-latency-metrics.provider.spec.ts
+++ b/src/modules/accounts/providers/account-latency-metrics.provider.spec.ts
@@ -1,0 +1,113 @@
+import { jest } from '@jest/globals';
+import { Test, TestingModule } from '@nestjs/testing';
+import { AccountLatencyMetricsProvider } from './account-latency-metrics.provider.js';
+
+describe('AccountLatencyMetricsProvider', () => {
+  let provider: AccountLatencyMetricsProvider;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [AccountLatencyMetricsProvider],
+    }).compile();
+    provider = module.get<AccountLatencyMetricsProvider>(
+      AccountLatencyMetricsProvider,
+    );
+  });
+
+  afterEach(() => jest.restoreAllMocks());
+
+  // ── basic recording ─────────────────────────────────────────────────────────
+
+  describe('record()', () => {
+    it('increments getTotalCount()', () => {
+      provider.record(200, true);
+      provider.record(300, false);
+      expect(provider.getTotalCount()).toBe(2);
+    });
+
+    it('counts only successful samples in getSuccessCount()', () => {
+      provider.record(100, true);
+      provider.record(200, false);
+      provider.record(150, true);
+      expect(provider.getSuccessCount()).toBe(2);
+    });
+
+    it('increments histogram buckets for samples within their bound', () => {
+      provider.record(100, true); // ≤ 100ms bucket
+      provider.record(300, true); // ≤ 500ms bucket (not ≤100)
+      const buckets = provider.getBuckets();
+      const b100 = buckets.find((b) => b.upperBoundMs === 100)!;
+      const b500 = buckets.find((b) => b.upperBoundMs === 500)!;
+      expect(b100.count).toBe(1);
+      expect(b500.count).toBe(2); // cumulative
+    });
+  });
+
+  // ── percentiles ─────────────────────────────────────────────────────────────
+
+  describe('percentile calculations', () => {
+    it('returns 0 when no samples recorded', () => {
+      expect(provider.getP99Ms()).toBe(0);
+      expect(provider.getP95Ms()).toBe(0);
+      expect(provider.getP50Ms()).toBe(0);
+    });
+
+    it('getP50Ms() returns median', () => {
+      [100, 200, 300, 400, 500].forEach((d) => provider.record(d, true));
+      expect(provider.getP50Ms()).toBe(300);
+    });
+
+    it('getP99Ms() returns near-max for many uniform samples', () => {
+      Array.from({ length: 100 }, (_, i) => provider.record(i + 1, true));
+      expect(provider.getP99Ms()).toBe(99);
+    });
+
+    it('getP95Ms() returns 95th percentile', () => {
+      Array.from({ length: 100 }, (_, i) => provider.record(i + 1, true));
+      expect(provider.getP95Ms()).toBe(95);
+    });
+  });
+
+  // ── alert ───────────────────────────────────────────────────────────────────
+
+  describe('p99 alert', () => {
+    it('emits warn log when p99 exceeds 5000ms', () => {
+      const warnSpy = jest
+        .spyOn(provider['logger'], 'warn')
+        .mockImplementation(() => {});
+
+      // Drive p99 above threshold: many slow samples
+      Array.from({ length: 100 }, () => provider.record(6_000, true));
+
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('ALERT'));
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('5000ms'));
+    });
+
+    it('does not emit warn when p99 is within threshold', () => {
+      const warnSpy = jest
+        .spyOn(provider['logger'], 'warn')
+        .mockImplementation(() => {});
+
+      provider.record(100, true);
+      provider.record(200, true);
+
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── buckets ─────────────────────────────────────────────────────────────────
+
+  describe('getBuckets()', () => {
+    it('returns all default bucket boundaries', () => {
+      const bounds = provider.getBuckets().map((b) => b.upperBoundMs);
+      expect(bounds).toContain(50);
+      expect(bounds).toContain(5_000);
+      expect(bounds).toContain(10_000);
+    });
+
+    it('all counts are 0 before any recording', () => {
+      const allZero = provider.getBuckets().every((b) => b.count === 0);
+      expect(allZero).toBe(true);
+    });
+  });
+});

--- a/src/modules/accounts/providers/account-latency-metrics.provider.ts
+++ b/src/modules/accounts/providers/account-latency-metrics.provider.ts
@@ -1,0 +1,79 @@
+import { Injectable, Logger } from '@nestjs/common';
+
+interface HistogramBucket {
+  upperBoundMs: number;
+  count: number;
+}
+
+interface LatencySample {
+  durationMs: number;
+  success: boolean;
+  recordedAt: Date;
+}
+
+const P99_ALERT_THRESHOLD_MS = 5_000;
+
+const DEFAULT_BUCKETS_MS = [50, 100, 250, 500, 1_000, 2_500, 5_000, 10_000];
+
+@Injectable()
+export class AccountLatencyMetricsProvider {
+  private readonly logger = new Logger(AccountLatencyMetricsProvider.name);
+  private readonly samples: LatencySample[] = [];
+  private readonly buckets: HistogramBucket[] = DEFAULT_BUCKETS_MS.map((b) => ({
+    upperBoundMs: b,
+    count: 0,
+  }));
+
+  record(durationMs: number, success: boolean): void {
+    this.samples.push({ durationMs, success, recordedAt: new Date() });
+    for (const bucket of this.buckets) {
+      if (durationMs <= bucket.upperBoundMs) {
+        bucket.count++;
+      }
+    }
+    this.checkAlert(durationMs);
+  }
+
+  getP99Ms(): number {
+    return this.percentile(99);
+  }
+
+  getP95Ms(): number {
+    return this.percentile(95);
+  }
+
+  getP50Ms(): number {
+    return this.percentile(50);
+  }
+
+  getTotalCount(): number {
+    return this.samples.length;
+  }
+
+  getSuccessCount(): number {
+    return this.samples.filter((s) => s.success).length;
+  }
+
+  getBuckets(): ReadonlyArray<{ upperBoundMs: number; count: number }> {
+    return this.buckets;
+  }
+
+  private percentile(p: number): number {
+    const sorted = [...this.samples]
+      .map((s) => s.durationMs)
+      .sort((a, b) => a - b);
+    if (sorted.length === 0) return 0;
+    const idx = Math.ceil((p / 100) * sorted.length) - 1;
+    return sorted[Math.max(0, idx)];
+  }
+
+  private checkAlert(durationMs: number): void {
+    const p99 = this.getP99Ms();
+    if (p99 > P99_ALERT_THRESHOLD_MS) {
+      this.logger.warn(
+        `ALERT: account_creation_latency p99=${p99}ms exceeds threshold of ${P99_ALERT_THRESHOLD_MS}ms ` +
+          `(latest sample: ${durationMs}ms, total_samples: ${this.samples.length})`,
+      );
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds a Prometheus-style histogram to track end-to-end `POST /accounts` latency with a p99 > 5 s alert.

- `AccountLatencyMetricsProvider` maintains cumulative bucket counts across 8 boundaries (50 ms – 10 s)
- Exposes `getP50Ms()`, `getP95Ms()`, `getP99Ms()`, `getTotalCount()`, `getSuccessCount()`, `getBuckets()`
- Emits a `warn` log whenever p99 exceeds the 5 000 ms SLO threshold
- `AccountsService.create()` calls `record(durationMs, success)` on both the success return and the catch block so every attempt is captured
- 11 unit tests covering recording, percentile calculations, bucket accumulation, and alert behaviour

**Files added/changed:**
- `src/modules/accounts/providers/account-latency-metrics.provider.ts`
- `src/modules/accounts/providers/account-latency-metrics.provider.spec.ts`
- `src/modules/accounts/accounts.service.ts`
- `src/modules/accounts/accounts.module.ts`

closes #188