### PR TITLE
feature: track sweep success rate as a core SLI (#88)

### DIFF
--- a/src/modules/sweeps/providers/sweep-metrics.provider.spec.ts
+++ b/src/modules/sweeps/providers/sweep-metrics.provider.spec.ts
@@ -1,0 +1,136 @@
+import { jest } from '@jest/globals';
+import { Test, TestingModule } from '@nestjs/testing';
+import { SweepMetricsProvider } from './sweep-metrics.provider.js';
+
+describe('SweepMetricsProvider', () => {
+  let provider: SweepMetricsProvider;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [SweepMetricsProvider],
+    }).compile();
+    provider = module.get<SweepMetricsProvider>(SweepMetricsProvider);
+  });
+
+  afterEach(() => jest.restoreAllMocks());
+
+  // ── counters ────────────────────────────────────────────────────────────────
+
+  describe('sweep_completed_total', () => {
+    it('starts at 0', () => {
+      expect(provider.getCompletedTotal()).toBe(0);
+    });
+
+    it('increments on each recordCompleted() call', () => {
+      provider.recordCompleted();
+      provider.recordCompleted();
+      expect(provider.getCompletedTotal()).toBe(2);
+    });
+
+    it('is independent of recordFailed()', () => {
+      provider.recordFailed();
+      expect(provider.getCompletedTotal()).toBe(0);
+    });
+  });
+
+  describe('sweep_failed_total', () => {
+    it('starts at 0', () => {
+      expect(provider.getFailedTotal()).toBe(0);
+    });
+
+    it('increments on each recordFailed() call', () => {
+      provider.recordFailed();
+      provider.recordFailed();
+      provider.recordFailed();
+      expect(provider.getFailedTotal()).toBe(3);
+    });
+
+    it('is independent of recordCompleted()', () => {
+      provider.recordCompleted();
+      expect(provider.getFailedTotal()).toBe(0);
+    });
+  });
+
+  // ── success rate ────────────────────────────────────────────────────────────
+
+  describe('getSuccessRate()', () => {
+    it('returns 1 when no sweeps have been recorded', () => {
+      expect(provider.getSuccessRate()).toBe(1);
+    });
+
+    it('returns 1 when all sweeps completed successfully', () => {
+      provider.recordCompleted();
+      provider.recordCompleted();
+      expect(provider.getSuccessRate()).toBe(1);
+    });
+
+    it('returns 0 when all sweeps failed', () => {
+      provider.recordFailed();
+      provider.recordFailed();
+      expect(provider.getSuccessRate()).toBe(0);
+    });
+
+    it('calculates the correct ratio with mixed outcomes', () => {
+      provider.recordCompleted(); // 1
+      provider.recordCompleted(); // 2
+      provider.recordCompleted(); // 3
+      provider.recordFailed(); // 1 failure → 3/4 = 0.75
+      expect(provider.getSuccessRate()).toBeCloseTo(0.75);
+    });
+  });
+
+  // ── snapshot ────────────────────────────────────────────────────────────────
+
+  describe('getSnapshot()', () => {
+    it('returns all three SLI fields', () => {
+      provider.recordCompleted();
+      provider.recordFailed();
+      const snap = provider.getSnapshot();
+      expect(snap).toHaveProperty('sweep_completed_total', 1);
+      expect(snap).toHaveProperty('sweep_failed_total', 1);
+      expect(snap).toHaveProperty('sweep_success_rate', 0.5);
+    });
+  });
+
+  // ── alert ───────────────────────────────────────────────────────────────────
+
+  describe('success-rate alert', () => {
+    it('emits a warn log when success rate drops below 95%', () => {
+      const warnSpy = jest
+        .spyOn(provider['logger'], 'warn')
+        .mockImplementation(() => {});
+
+      // 5 completed + 1 failed → 83.3% success rate (below 95%)
+      for (let i = 0; i < 5; i++) provider.recordCompleted();
+      provider.recordFailed();
+
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('ALERT'));
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('sweep_success_rate'),
+      );
+    });
+
+    it('does not warn when success rate is at or above 95%', () => {
+      const warnSpy = jest
+        .spyOn(provider['logger'], 'warn')
+        .mockImplementation(() => {});
+
+      // 19 completed + 1 failed → 95% success rate
+      for (let i = 0; i < 19; i++) provider.recordCompleted();
+      provider.recordFailed();
+
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it('does not warn when all sweeps succeed', () => {
+      const warnSpy = jest
+        .spyOn(provider['logger'], 'warn')
+        .mockImplementation(() => {});
+
+      provider.recordCompleted();
+      provider.recordCompleted();
+
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/modules/sweeps/providers/sweep-metrics.provider.ts
+++ b/src/modules/sweeps/providers/sweep-metrics.provider.ts
@@ -1,0 +1,60 @@
+import { Injectable, Logger } from '@nestjs/common';
+
+const LOW_SUCCESS_RATE_THRESHOLD = 0.95;
+
+@Injectable()
+export class SweepMetricsProvider {
+  private readonly logger = new Logger(SweepMetricsProvider.name);
+
+  private sweepCompletedTotal = 0;
+  private sweepFailedTotal = 0;
+
+  recordCompleted(): void {
+    this.sweepCompletedTotal++;
+    this.checkSuccessRate();
+  }
+
+  recordFailed(): void {
+    this.sweepFailedTotal++;
+    this.checkSuccessRate();
+  }
+
+  getCompletedTotal(): number {
+    return this.sweepCompletedTotal;
+  }
+
+  getFailedTotal(): number {
+    return this.sweepFailedTotal;
+  }
+
+  getSuccessRate(): number {
+    const total = this.sweepCompletedTotal + this.sweepFailedTotal;
+    if (total === 0) return 1;
+    return this.sweepCompletedTotal / total;
+  }
+
+  getSnapshot(): {
+    sweep_completed_total: number;
+    sweep_failed_total: number;
+    sweep_success_rate: number;
+  } {
+    return {
+      sweep_completed_total: this.sweepCompletedTotal,
+      sweep_failed_total: this.sweepFailedTotal,
+      sweep_success_rate: this.getSuccessRate(),
+    };
+  }
+
+  private checkSuccessRate(): void {
+    const total = this.sweepCompletedTotal + this.sweepFailedTotal;
+    if (total === 0) return;
+    const rate = this.getSuccessRate();
+    if (rate < LOW_SUCCESS_RATE_THRESHOLD) {
+      this.logger.warn(
+        `ALERT: sweep_success_rate=${(rate * 100).toFixed(2)}% is below ` +
+          `${LOW_SUCCESS_RATE_THRESHOLD * 100}% threshold ` +
+          `(completed=${this.sweepCompletedTotal}, failed=${this.sweepFailedTotal})`,
+      );
+    }
+  }
+}

--- a/src/modules/sweeps/sweeps.module.ts
+++ b/src/modules/sweeps/sweeps.module.ts
@@ -4,6 +4,7 @@ import { SweepsService } from './sweeps.service.js';
 import { ValidationProvider } from './providers/validation.provider.js';
 import { ContractProvider } from './providers/contract.provider.js';
 import { TransactionProvider } from './providers/transaction.provider.js';
+import { SweepMetricsProvider } from './providers/sweep-metrics.provider.js';
 import { Account } from '../accounts/entities/account.entity.js';
 import { StellarModule } from '../stellar/stellar.module.js';
 
@@ -14,6 +15,7 @@ import { StellarModule } from '../stellar/stellar.module.js';
     ValidationProvider,
     ContractProvider,
     TransactionProvider,
+    SweepMetricsProvider,
   ],
   exports: [SweepsService],
 })

--- a/src/modules/sweeps/sweeps.service.spec.ts
+++ b/src/modules/sweeps/sweeps.service.spec.ts
@@ -6,6 +6,7 @@ import { ContractProvider } from './providers/contract.provider.js';
 import { TransactionProvider } from './providers/transaction.provider.js';
 import { StellarService } from '../stellar/stellar.service.js';
 import { ConfigService } from '@nestjs/config';
+import { SweepMetricsProvider } from './providers/sweep-metrics.provider.js';
 
 // ---------------------------------------------------------------------------
 // Shared fixtures
@@ -88,6 +89,7 @@ describe('SweepsService', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         SweepsService,
+        SweepMetricsProvider,
         { provide: ValidationProvider, useValue: validationProvider },
         { provide: ContractProvider, useValue: contractProvider },
         { provide: TransactionProvider, useValue: transactionProvider },

--- a/src/modules/sweeps/sweeps.service.ts
+++ b/src/modules/sweeps/sweeps.service.ts
@@ -7,6 +7,7 @@ import { StellarService } from '../stellar/stellar.service.js';
 import type { SweepExecutionRequest } from './interfaces/execute-sweep.interface.js';
 import type { SweepResult } from './interfaces/sweep-result.interface.js';
 import { TransactionResult } from './interfaces/transaction-result.interface.js';
+import { SweepMetricsProvider } from './providers/sweep-metrics.provider.js';
 
 @Injectable()
 export class SweepsService {
@@ -18,6 +19,7 @@ export class SweepsService {
     private readonly transactionProvider: TransactionProvider,
     private readonly stellarService: StellarService,
     private readonly configService: ConfigService,
+    private readonly sweepMetrics: SweepMetricsProvider,
   ) {}
 
   /**
@@ -98,10 +100,12 @@ export class SweepsService {
           `Error: ${(error as Error).message}`,
         (error as Error).stack,
       );
+      this.sweepMetrics.recordFailed();
       throw error;
     }
 
     this.logger.log(`Sweep complete: txHash=${transactionResult.hash}`);
+    this.sweepMetrics.recordCompleted();
 
     return {
       success: true,


### PR DESCRIPTION
## Summary

Adds `sweep_completed_total` and `sweep_failed_total` counters with a derived success-rate SLI.

- `SweepMetricsProvider` maintains the two counters and computes `sweep_success_rate = completed / (completed + failed)`
- `getSnapshot()` returns all three values for health/metrics endpoints
- A `warn` log is emitted whenever the success rate drops below the 95 % threshold, including current counts
- `SweepsService.executeSweep()` calls `recordCompleted()` on success and `recordFailed()` in the Horizon-payment catch block
- Existing `SweepsService` spec updated to inject the new provider — all 17 original tests still pass
- 13 new unit tests covering counters, success-rate calculation, snapshot shape, and alert behaviour

**Files added/changed:**
- `src/modules/sweeps/providers/sweep-metrics.provider.ts`
- `src/modules/sweeps/providers/sweep-metrics.provider.spec.ts`
- `src/modules/sweeps/sweeps.service.ts`
- `src/modules/sweeps/sweeps.service.spec.ts`
- `src/modules/sweeps/sweeps.module.ts`

closes #189