### PR TITLE
Test: Add token verification error propagation tests (#167)

### DIFF
--- a/src/modules/claims/providers/claim-redemption.provider.spec.ts
+++ b/src/modules/claims/providers/claim-redemption.provider.spec.ts
@@ -354,4 +354,36 @@ describe('ClaimRedemptionProvider', () => {
       ).rejects.toThrow('Stellar network error');
     });
   });
+
+  describe('redeemClaim - propagates TokenVerification errors (issue #167)', () => {
+    it('rethrows BadRequestException when token is expired', async () => {
+      mockTokenVerificationProvider.verifyClaimToken.mockRejectedValue(
+        new BadRequestException('Token has expired'),
+      );
+
+      await expect(
+        provider.redeemClaim(VALID_TOKEN, VALID_DESTINATION),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('rethrows BadRequestException when token does not match the requested account', async () => {
+      mockTokenVerificationProvider.verifyClaimToken.mockRejectedValue(
+        new BadRequestException('Token does not match the requested account'),
+      );
+
+      await expect(
+        provider.redeemClaim(VALID_TOKEN, VALID_DESTINATION),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('rethrows BadRequestException for malformed JWT', async () => {
+      mockTokenVerificationProvider.verifyClaimToken.mockRejectedValue(
+        new BadRequestException('jwt malformed'),
+      );
+
+      await expect(
+        provider.redeemClaim(VALID_TOKEN, VALID_DESTINATION),
+      ).rejects.toThrow(BadRequestException);
+    });
+  });
 });


### PR DESCRIPTION
## Closes #167
Closes #165 

## What
Adds three unit tests to `ClaimRedemptionProvider`'s spec (in `src/modules/claims/providers/claim-redemption.provider.spec.ts`) covering the token-verification error propagation paths from the issue checklist that were not previously asserted in this scope:

- `rethrows BadRequestException when token is expired`
- `rethrows BadRequestException when token does not match the requested account` (wrong account)
- `rethrows BadRequestException for malformed JWT`

Each mocks `TokenVerificationProvider.verifyClaimToken` to throw `BadRequestException` with the failing message, then asserts that `ClaimRedemptionProvider.redeemClaim` rethrows the exception class -- pinning that the redemption flow does not swallow token-verification errors.

## Already covered upstream
The existing spec for this provider already covers:

- Successful redemption (4 cases incl. SELECT FOR UPDATE lock verification)
- Double-spend rejection via concurrent CLAIMING state (`ConflictException`)
- Destination Stellar-address validation (format / prefix / length / hex)
- Sweep-failure rollback to `PENDING_CLAIM`

So the issue case categorization maps to existing + new tests as follows:

- token generation -> out of this PR scope (see below)
- token validation (expired / wrong account / malformed) -> **added in this PR**
- successful redemption flow -> already covered upstream
- double-spend rejection -> already covered upstream
- destination validation failure -> already covered upstream

## Scope note: token generation
The `token generation` case from the issue's checklist is **not testable in `ClaimsService` or `ClaimRedemptionProvider`**: token issuance / hash storage happens earlier in `AccountsService.createAccount`. The plaintext token is returned to the API caller at account-creation time, only its hash is persisted. Coverage for that flow will be added in a separate PR.

## Testing
- `npx jest --testPathPattern=modules/claims/providers/claim-redemption` -> 17/17 passed (3 new + 14 existing)
- `npx tsc --noEmit -p tsconfig.json` -> clean for this file
- `npx eslint` -> clean for this file
- `npx prettier --check` -> clean for this file
- Working tree clean except for the one spec file

## Branch
`fix/issue-167-add-unit-tests-claims-service-and-redemption-provider`
