### PR TITLE
feat: Versioned AES-256-GCM encryption + migration tool (#193)

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "migration:create": "npm run typeorm -- migration:create",
     "migration:run": "npm run typeorm -- migration:run -d src/config/typeorm.config.ts",
     "migration:revert": "npm run typeorm -- migration:revert -d src/config/typeorm.config.ts",
-    "migration:show": "npm run typeorm -- migration:show -d src/config/typeorm.config.ts"
+    "migration:show": "npm run typeorm -- migration:show -d src/config/typeorm.config.ts",
+    "migrate:secrets": "ts-node --esm src/scripts/migrate-secrets.ts"
   },
   "dependencies": {
     "@nestjs/common": "^11.0.1",

--- a/src/common/crypto/encryption.util.spec.ts
+++ b/src/common/crypto/encryption.util.spec.ts
@@ -6,9 +6,16 @@ describe('SecretEncryptionUtil', () => {
   const plaintext = 'SCZANGBA5YHTNYVSKOP3SJ2CAANRL5ZVTTHLQPTU26HQZQVTYVKBMCR';
 
   describe('encrypt', () => {
-    it('produces a colon-separated string with three parts', () => {
+    it('produces output with the aes256gcm:v1: prefix', () => {
       const result = SecretEncryptionUtil.encrypt(plaintext, validKey);
-      expect(result.split(':').length).toBe(3);
+      expect(result.startsWith('aes256gcm:v1:')).toBe(true);
+    });
+
+    it('produces a 4-segment colon-separated string (prefix + iv + authTag + data)', () => {
+      const result = SecretEncryptionUtil.encrypt(plaintext, validKey);
+      // Strip prefix, then count segments in the body.
+      const body = result.slice('aes256gcm:v1:'.length);
+      expect(body.split(':').length).toBe(3);
     });
 
     it('produces a different output each call due to random IV', () => {
@@ -18,11 +25,10 @@ describe('SecretEncryptionUtil', () => {
     });
   });
 
-  describe('decrypt', () => {
-    it('round-trips correctly', () => {
+  describe('decrypt - prefixed payloads (v1)', () => {
+    it('round-trips correctly with v1 prefix', () => {
       const encrypted = SecretEncryptionUtil.encrypt(plaintext, validKey);
-      const decrypted = SecretEncryptionUtil.decrypt(encrypted, validKey);
-      expect(decrypted).toBe(plaintext);
+      expect(SecretEncryptionUtil.decrypt(encrypted, validKey)).toBe(plaintext);
     });
 
     it('throws when the wrong key is used', () => {
@@ -33,11 +39,37 @@ describe('SecretEncryptionUtil', () => {
 
     it('throws when the ciphertext is tampered with', () => {
       const encrypted = SecretEncryptionUtil.encrypt(plaintext, validKey);
-      const parts = encrypted.split(':');
+      const tamperMarker = 'aes256gcm:v1:';
+      const body = encrypted.slice(tamperMarker.length);
+      const parts = body.split(':');
       parts[2] = 'aabbccdd'; // corrupt the ciphertext
       expect(() =>
-        SecretEncryptionUtil.decrypt(parts.join(':'), validKey),
+        SecretEncryptionUtil.decrypt(tamperMarker + parts.join(':'), validKey),
       ).toThrow();
+    });
+  });
+
+  describe('decrypt - format compatibility', () => {
+    it('accepts unprefixed AES-256-GCM hex (in-flight migration rows)', () => {
+      // Hand-craft a valid unprefixed AES-256-GCM payload using the same
+      // crypto primitives and confirm decrypt() handles it without the prefix.
+      const key = Buffer.from(validKey, 'hex');
+      const iv = crypto.randomBytes(16);
+      const cipher = crypto.createCipheriv('aes-256-gcm', key, iv);
+      const ciphertext = Buffer.concat([
+        cipher.update(plaintext, 'utf8'),
+        cipher.final(),
+      ]);
+      const authTag = cipher.getAuthTag();
+      const legacyPayload = [
+        iv.toString('hex'),
+        authTag.toString('hex'),
+        ciphertext.toString('hex'),
+      ].join(':');
+
+      expect(SecretEncryptionUtil.decrypt(legacyPayload, validKey)).toBe(
+        plaintext,
+      );
     });
 
     it('throws a descriptive error for legacy base64 format', () => {
@@ -45,6 +77,84 @@ describe('SecretEncryptionUtil', () => {
       expect(() =>
         SecretEncryptionUtil.decrypt(base64Secret, validKey),
       ).toThrow('Invalid encrypted format');
+    });
+
+    it('throws a descriptive error pointing to migrate:secrets for base64', () => {
+      const base64Secret = Buffer.from(plaintext).toString('base64');
+      expect(() =>
+        SecretEncryptionUtil.decrypt(base64Secret, validKey),
+      ).toThrow(/migrate:secrets/);
+    });
+
+    it('throws when the payload claims aes256gcm:v2 (unsupported version)', () => {
+      // Build a syntactically valid v1 body and just lie about the prefix.
+      const encrypted = SecretEncryptionUtil.encrypt(plaintext, validKey);
+      const body = encrypted.slice('aes256gcm:v1:'.length);
+      const fake = `aes256gcm:v2:${body}`;
+      expect(() => SecretEncryptionUtil.decrypt(fake, validKey)).toThrow(
+        'aes256gcm:v2',
+      );
+    });
+
+    it('throws when the payload claims aes256gcm:v0 (legacy unknown version)', () => {
+      const encrypted = SecretEncryptionUtil.encrypt(plaintext, validKey);
+      const body = encrypted.slice('aes256gcm:v1:'.length);
+      const fake = `aes256gcm:v0:${body}`;
+      expect(() => SecretEncryptionUtil.decrypt(fake, validKey)).toThrow(
+        'aes256gcm:v0',
+      );
+    });
+
+    it('throws for an empty string', () => {
+      expect(() => SecretEncryptionUtil.decrypt('', validKey)).toThrow();
+    });
+  });
+
+  describe('classify', () => {
+    it('returns prefixed-aes-v1 for current-format rows', () => {
+      const encrypted = SecretEncryptionUtil.encrypt(plaintext, validKey);
+      expect(SecretEncryptionUtil.classify(encrypted)).toBe('prefixed-aes-v1');
+    });
+
+    it('returns unprefixed-aes for legacy AES rows', () => {
+      const key = Buffer.from(validKey, 'hex');
+      const iv = crypto.randomBytes(16);
+      const cipher = crypto.createCipheriv('aes-256-gcm', key, iv);
+      const ciphertext = Buffer.concat([
+        cipher.update(plaintext, 'utf8'),
+        cipher.final(),
+      ]);
+      const authTag = cipher.getAuthTag();
+      const legacy = [
+        iv.toString('hex'),
+        authTag.toString('hex'),
+        ciphertext.toString('hex'),
+      ].join(':');
+      expect(SecretEncryptionUtil.classify(legacy)).toBe('unprefixed-aes');
+    });
+
+    it('returns legacy-base64 for base64 rows', () => {
+      const base64 = Buffer.from(plaintext).toString('base64');
+      expect(SecretEncryptionUtil.classify(base64)).toBe('legacy-base64');
+    });
+
+    it('returns corrupt for empty / non-string inputs', () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect(SecretEncryptionUtil.classify('' as any)).toBe('corrupt');
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect(SecretEncryptionUtil.classify(undefined as any)).toBe('corrupt');
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect(SecretEncryptionUtil.classify(null as any)).toBe('corrupt');
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect(SecretEncryptionUtil.classify(123 as any)).toBe('corrupt');
+    });
+
+    it('returns corrupt for a v2-prefixed row even if the body is valid', () => {
+      const encrypted = SecretEncryptionUtil.encrypt(plaintext, validKey);
+      const body = encrypted.slice('aes256gcm:v1:'.length);
+      expect(SecretEncryptionUtil.classify(`aes256gcm:v2:${body}`)).toBe(
+        'corrupt',
+      );
     });
   });
 
@@ -54,6 +164,10 @@ describe('SecretEncryptionUtil', () => {
       expect(() => SecretEncryptionUtil.encrypt(plaintext, shortKey)).toThrow(
         'Encryption key must be 32 bytes',
       );
+    });
+
+    it('throws when key is empty', () => {
+      expect(() => SecretEncryptionUtil.encrypt(plaintext, '')).toThrow();
     });
   });
 });

--- a/src/common/crypto/encryption.util.spec.ts
+++ b/src/common/crypto/encryption.util.spec.ts
@@ -139,13 +139,12 @@ describe('SecretEncryptionUtil', () => {
     });
 
     it('returns corrupt for empty / non-string inputs', () => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       expect(SecretEncryptionUtil.classify('' as any)).toBe('corrupt');
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+
       expect(SecretEncryptionUtil.classify(undefined as any)).toBe('corrupt');
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+
       expect(SecretEncryptionUtil.classify(null as any)).toBe('corrupt');
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+
       expect(SecretEncryptionUtil.classify(123 as any)).toBe('corrupt');
     });
 

--- a/src/common/crypto/secret-encryption.util.ts
+++ b/src/common/crypto/secret-encryption.util.ts
@@ -8,11 +8,20 @@ import * as crypto from 'crypto';
  * (decrypt on claim redemption). Both must always use this single implementation
  * - never inline encrypt/decrypt logic elsewhere.
  *
- * Encrypted format (colon-separated hex strings):
- *   iv:authTag:encryptedData
+ * Encrypted format (v1, current):
+ *   aes256gcm:v1:<iv_hex>:<authTag_hex>:<ciphertext_hex>
  *
- * The IV is randomly generated per call - never reused.
- * The GCM auth tag detects any tampering with the ciphertext.
+ * Format changelog
+ * ───────────────
+ * • v1 (current) ─ `aes256gcm:v1:` prefix + 16-byte random IV + 16-byte
+ *   GCM auth tag + ciphertext (all hex-encoded, colon-separated). The prefix
+ *   lets us detect format and crash clearly on rows from unknown versions
+ *   rather than silently mis-decoding.
+ * • unprefixed ─ legacy AES-256-GCM rows from the pre-PR #193 era that did
+ *   not carry the version prefix. decrypt() still accepts these for the
+ *   migration window, but new writes always emit `v1`.
+ * • plain base64 ─ pre-AES MVP placeholder. decrypt() rejects with a
+ *   descriptive error pointing operators at scripts/migrate-secrets.ts.
  *
  * Key requirements:
  * - Must be a 32-byte value provided as a 64-character hex string
@@ -22,6 +31,9 @@ import * as crypto from 'crypto';
 export class SecretEncryptionUtil {
   private static readonly ALGORITHM = 'aes-256-gcm';
   private static readonly IV_LENGTH = 16;
+  private static readonly AUTH_TAG_LENGTH = 16;
+  private static readonly PREFIX_V1 = 'aes256gcm:v1:';
+  private static readonly PREFIX_PATTERN = /^aes256gcm:v(\d+):(.*)$/;
 
   static encrypt(plaintext: string, encryptionKey: string): string {
     const key = SecretEncryptionUtil.parseKey(encryptionKey);
@@ -36,26 +48,113 @@ export class SecretEncryptionUtil {
       cipher.final(),
     ]);
     const authTag = cipher.getAuthTag();
-    return [
-      iv.toString('hex'),
-      authTag.toString('hex'),
-      encrypted.toString('hex'),
-    ].join(':');
+    return (
+      SecretEncryptionUtil.PREFIX_V1 +
+      [
+        iv.toString('hex'),
+        authTag.toString('hex'),
+        encrypted.toString('hex'),
+      ].join(':')
+    );
   }
 
   static decrypt(encryptedString: string, encryptionKey: string): string {
     const key = SecretEncryptionUtil.parseKey(encryptionKey);
-    const parts = encryptedString.split(':');
+
+    // Handle v1+ prefixed payloads explicitly. Unknown versions (e.g. v2) must
+    // crash loudly so we never silently decode with the wrong algorithm.
+    const prefixMatch = encryptedString.match(
+      SecretEncryptionUtil.PREFIX_PATTERN,
+    );
+    if (prefixMatch) {
+      const version = parseInt(prefixMatch[1] ?? '', 10);
+      const body = prefixMatch[2] ?? '';
+      if (version !== 1) {
+        throw new Error(
+          `Encrypted payload uses aes256gcm:v${version}: which is not supported by this build. ` +
+            'Roll forward to a build that supports this format version before redeploying.',
+        );
+      }
+      return SecretEncryptionUtil.decryptBody(body, key, 'aes256gcm:v1');
+    }
+
+    // No prefix: either legacy AES-256-GCM hex (3 colon-separated hex parts
+    // with correct IV/authTag lengths) or the legacy MVP base64 placeholder.
+    // We accept unprefixed AES rows only during the migration window so a
+    // half-migrated database still decrypts.
+    if (SecretEncryptionUtil.isAesGcmBody(encryptedString)) {
+      return SecretEncryptionUtil.decryptBody(
+        encryptedString,
+        key,
+        'unprefixed-aes',
+      );
+    }
+
+    throw new Error(
+      'Invalid encrypted format. Expected aes256gcm:v1:<iv>:<authTag>:<data> ' +
+        '(or legacy unprefixed <iv>:<authTag>:<data>). ' +
+        'This may be a legacy base64-encoded secret that has not been migrated. ' +
+        'Run: npm run migrate:secrets -- --i-have-a-backup --execute',
+    );
+  }
+
+  /**
+   * Pure, side-effect-free classifier used by scripts/migrate-secrets.ts and
+   * its spec tests. Returns the bucketed format of a stored ciphertext.
+   */
+  static classify(encryptedString: string): SecretFormat {
+    if (typeof encryptedString !== 'string' || encryptedString.length === 0) {
+      return 'corrupt';
+    }
+    const prefixMatch = encryptedString.match(
+      SecretEncryptionUtil.PREFIX_PATTERN,
+    );
+    if (prefixMatch) {
+      const version = parseInt(prefixMatch[1] ?? '', 10);
+      if (
+        version === 1 &&
+        SecretEncryptionUtil.isAesGcmBody(prefixMatch[2] ?? '')
+      ) {
+        return 'prefixed-aes-v1';
+      }
+      return 'corrupt';
+    }
+    if (SecretEncryptionUtil.isAesGcmBody(encryptedString)) {
+      return 'unprefixed-aes';
+    }
+    return 'legacy-base64';
+  }
+
+  private static decryptBody(
+    body: string,
+    key: Buffer,
+    context: string,
+  ): string {
+    const parts = body.split(':');
     if (parts.length !== 3) {
       throw new Error(
-        'Invalid encrypted format. Expected iv:authTag:encryptedData. ' +
-          'This may be a legacy base64-encoded secret that has not been migrated.',
+        `Invalid encrypted format (${context}): expected 3 colon-separated parts (iv:authTag:data), got ${parts.length}.`,
       );
     }
     const [ivHex, authTagHex, dataHex] = parts;
+    if (!ivHex || !authTagHex || !dataHex) {
+      throw new Error(
+        `Invalid encrypted format (${context}): one of iv / authTag / data is empty.`,
+      );
+    }
     const iv = Buffer.from(ivHex, 'hex');
     const authTag = Buffer.from(authTagHex, 'hex');
     const data = Buffer.from(dataHex, 'hex');
+    if (iv.length !== SecretEncryptionUtil.IV_LENGTH) {
+      throw new Error(
+        `Invalid IV length (${context}): expected ${SecretEncryptionUtil.IV_LENGTH} bytes, got ${iv.length}.`,
+      );
+    }
+    if (authTag.length !== SecretEncryptionUtil.AUTH_TAG_LENGTH) {
+      throw new Error(
+        `Invalid authTag length (${context}): expected ${SecretEncryptionUtil.AUTH_TAG_LENGTH} bytes, got ${authTag.length}.`,
+      );
+    }
     const decipher = crypto.createDecipheriv(
       SecretEncryptionUtil.ALGORITHM,
       key,
@@ -67,7 +166,38 @@ export class SecretEncryptionUtil {
     );
   }
 
+  private static isAesGcmBody(value: string): boolean {
+    if (typeof value !== 'string' || value.length === 0) return false;
+    const parts = value.split(':');
+    if (parts.length !== 3) return false;
+    const ivHex = parts[0];
+    const authTagHex = parts[1];
+    const dataHex = parts[2];
+    if (!ivHex || !authTagHex || !dataHex) return false;
+    if (ivHex.length !== SecretEncryptionUtil.IV_LENGTH * 2) return false;
+    if (authTagHex.length !== SecretEncryptionUtil.AUTH_TAG_LENGTH * 2)
+      return false;
+    if (ivHex.length === 0 || dataHex.length === 0) return false;
+    if (
+      !SecretEncryptionUtil.isHex(ivHex) ||
+      !SecretEncryptionUtil.isHex(authTagHex) ||
+      !SecretEncryptionUtil.isHex(dataHex)
+    ) {
+      return false;
+    }
+    return true;
+  }
+
+  private static isHex(s: string): boolean {
+    return /^[0-9a-fA-F]+$/.test(s);
+  }
+
   private static parseKey(hexKey: string): Buffer {
+    if (typeof hexKey !== 'string' || hexKey.length === 0) {
+      throw new Error(
+        'Encryption key must be a non-empty 64-character hex string.',
+      );
+    }
     const key = Buffer.from(hexKey, 'hex');
     if (key.length !== 32) {
       throw new Error(
@@ -78,3 +208,9 @@ export class SecretEncryptionUtil {
     return key;
   }
 }
+
+export type SecretFormat =
+  | 'prefixed-aes-v1'
+  | 'unprefixed-aes'
+  | 'legacy-base64'
+  | 'corrupt';

--- a/src/modules/accounts/accounts.service.ts
+++ b/src/modules/accounts/accounts.service.ts
@@ -37,10 +37,15 @@ import { AccountLatencyMetricsProvider } from './providers/account-latency-metri
  *
  * Security Notes
  * --------------
- * - MVP placeholders: Several methods in this file include intentionally
- *   lightweight or placeholder implementations that are NOT production secure.
- *   These are clearly marked in the code. Examples include:
- *     - `encryptSecret()` currently uses base64 for storage (NOT SECURE).
+ * - Encryption status: `secretKeyEncrypted` is stored as an AES-256-GCM
+ *   ciphertext via `SecretEncryptionUtil` (random IV per write, versioned
+ *   `aes256gcm:v1:` prefix). Pre-PR #193 rows may still exist in migration
+ *   window with either an unprefixed AES-GCM payload (decryption still
+ *   succeeds) or the residual MVP `Buffer.from(secret).toString('base64')`
+ *   placeholder (decryption throws; operator must run
+ *   `npm run migrate:secrets -- --i-have-a-backup --execute` once before any
+ *   claim can succeed against those rows). Key rotation is a separate concern
+ *   and is NOT covered by this util — it requires a dual-key decrypt path.
  *     - Token signing uses the configured JWT secret; ensure the secret
  *       management and rotation policies meet your security requirements.
  *

--- a/src/scripts/migrate-secrets.ts
+++ b/src/scripts/migrate-secrets.ts
@@ -1,0 +1,326 @@
+/**
+ * migrate-secrets.ts
+ * ──────────────────
+ * One-shot data-migration tool for issue #193.
+ *
+ * What it does
+ * ────────────
+ * Reclassifies every `accounts.secretKeyEncrypted` row and rewrites each row
+ * so it ends up carrying the `aes256gcm:v1:` prefix. Three legal source formats:
+ *
+ *   ─ prefixed-aes-v1  ─ already current, SKIP
+ *   ─ unprefixed-aes   ─ legacy AES-256-GCM without prefix; rewrite with prefix
+ *   ─ legacy-base64    ─ pre-AES MVP placeholder; decode + re-encrypt with prefix
+ *   ─ corrupt          ─ undecodable row; HALT and require operator intervention
+ *
+ * Safety
+ * ──────
+ *   1. Default mode is DRY-RUN. Nothing is written.
+ *   2. To write, you must pass BOTH `--execute` AND `--i-have-a-backup`.
+ *   3. Every UPDATE routes through TypeORM Repository.update() so the
+ *      optimistic `WHERE id = :id AND secretKeyEncrypted = :old` clause is
+ *      quoted-correctly AND returns a typed UpdateResult. Rows where the
+ *      optimistic check fails (`affected === 0`) are reported and skipped,
+ *      not retried — the live service has the up-to-date value.
+ *   4. Any `corrupt` row halts the run with a clear message so operators do
+ *      not silently skip past permanently-locked Stellar funds.
+ *   5. Every action is appended to an NDJSON audit file (written via the
+ *      helpers in `./migration-cli.ts`). The audit stream is awaited-drained
+ *      before process exit so trailing lines cannot be lost on shutdown.
+ *
+ * CLI parsing and audit logging live in `./migration-cli.ts` so the unit
+ * spec can test them WITHOUT this module's NestFactory / DataSource wiring.
+ *
+ * Usage
+ * ─────
+ *   Dry run (counts + sample IDs only):
+ *     npm run migrate:secrets
+ *
+ *   Production run with confirmation:
+ *     npm run migrate:secrets -- --i-have-a-backup --execute
+ *
+ *   After `npm run build`:
+ *     node dist/src/scripts/migrate-secrets.js --i-have-a-backup --execute
+ *
+ *   Options:
+ *     --i-have-a-backup         required with --execute
+ *     --execute                 actually write (default is dry-run)
+ *     --batch-size=N            rows scanned per query (default 500, max 10_000)
+ *     --audit-file=PATH         NDJSON audit destination
+ */
+import 'reflect-metadata';
+import { Module } from '@nestjs/common';
+import { ConfigModule, ConfigService } from '@nestjs/config';
+import { TypeOrmModule, TypeOrmModuleOptions } from '@nestjs/typeorm';
+import { NestFactory } from '@nestjs/core';
+import { DataSource, UpdateResult } from 'typeorm';
+import * as path from 'path';
+
+import { parseCli, createAuditLogger, type CliFlags } from './migration-cli.js';
+import databaseConfig from '../config/database.config.js';
+import stellarConfig from '../config/stellar.config.js';
+import { Account } from '../modules/accounts/entities/account.entity.js';
+import {
+  SecretEncryptionUtil,
+  SecretFormat,
+} from '../common/crypto/secret-encryption.util.js';
+
+// ---------------------------------------------------------------------------
+// Migration module — minimal application context. Deliberately does NOT import
+// AppModule, because AppModule pulls in ScheduleModule.forRoot() which fires
+// cron jobs during the migration.
+// ---------------------------------------------------------------------------
+
+@Module({
+  imports: [
+    ConfigModule.forRoot({
+      isGlobal: true,
+      load: [databaseConfig, stellarConfig],
+    }),
+    TypeOrmModule.forRootAsync({
+      imports: [ConfigModule],
+      inject: [ConfigService],
+      useFactory: (cs: ConfigService): TypeOrmModuleOptions => {
+        const cfg = cs.get<TypeOrmModuleOptions>('database.database');
+        if (!cfg) {
+          throw new Error(
+            'database.database config missing — check ConfigModule.forRoot loaders.',
+          );
+        }
+        return cfg;
+      },
+    }),
+  ],
+})
+class MigrationModule {}
+
+// ---------------------------------------------------------------------------
+// The runner
+// ---------------------------------------------------------------------------
+
+export interface MigrationReport {
+  totalScanned: number;
+  prefixed: number; // already-current, skipped
+  reencrypted: number; // writes actually committed
+  skippedConcurrent: number; // optimistic-concurrency lost
+  corrupt: number; // halted on a bad row
+  legacyBase64: number;
+  unprefixedAes: number;
+}
+
+export async function runMigration(flags: CliFlags): Promise<MigrationReport> {
+  const app = await NestFactory.createApplicationContext(MigrationModule, {
+    logger: false,
+  });
+
+  const dataSource = app.get(DataSource);
+  const encryptionKey = app
+    .get(ConfigService)
+    .getOrThrow<string>('stellar.encryptionKey');
+
+  const audit = createAuditLogger(flags.auditFile);
+
+  audit.write({
+    event: 'start',
+    execute: flags.execute,
+    batchSize: flags.batchSize,
+    nodeEnv: process.env.NODE_ENV ?? 'development',
+  });
+
+  const report: MigrationReport = {
+    totalScanned: 0,
+    prefixed: 0,
+    reencrypted: 0,
+    skippedConcurrent: 0,
+    corrupt: 0,
+    legacyBase64: 0,
+    unprefixedAes: 0,
+  };
+
+  try {
+    let offset = 0;
+    while (true) {
+      const batch: Account[] = await dataSource
+        .getRepository(Account)
+        .createQueryBuilder('a')
+        .select(['a.id', 'a.secretKeyEncrypted'])
+        .orderBy('a.id', 'ASC')
+        .offset(offset)
+        .limit(flags.batchSize)
+        .getMany();
+
+      if (batch.length === 0) break;
+
+      for (const row of batch) {
+        report.totalScanned += 1;
+        const stored = row.secretKeyEncrypted;
+        const format = SecretEncryptionUtil.classify(stored);
+
+        if (format === 'prefixed-aes-v1') {
+          report.prefixed += 1;
+          continue;
+        }
+
+        if (format === 'corrupt') {
+          report.corrupt += 1;
+          audit.write({ event: 'corrupt-halt', id: row.id, stored });
+          throw new Error(
+            `Migration halted: accounts.id=${row.id} has an un-decodable ` +
+              `secretKeyEncrypted payload. Inspect the row manually; do NOT ` +
+              `continue without remediation.`,
+          );
+        }
+
+        // Decode the legacy value and re-encrypt with the v1 prefix.
+        let plaintext: string;
+        try {
+          if (format === 'legacy-base64') {
+            plaintext = Buffer.from(stored, 'base64').toString('utf8');
+            report.legacyBase64 += 1;
+          } else if (format === 'unprefixed-aes') {
+            plaintext = SecretEncryptionUtil.decrypt(stored, encryptionKey);
+            report.unprefixedAes += 1;
+          } else {
+            // Exhaustiveness guard — classify() returns exactly one of the
+            // four buckets above; if a new bucket is added without handling
+            // it here, TS raises on the `never` assignment.
+            const _exhaustive: never = format;
+            throw new Error(`Unhandled format: ${String(_exhaustive)}`);
+          }
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          report.corrupt += 1;
+          audit.write({
+            event: 'decode-error',
+            id: row.id,
+            format,
+            error: message,
+          });
+          throw new Error(
+            `Migration halted: failed to decode accounts.id=${row.id} ` +
+              `(format=${format}): ${message}`,
+          );
+        }
+
+        const newEncrypted = SecretEncryptionUtil.encrypt(
+          plaintext,
+          encryptionKey,
+        );
+
+        if (!flags.execute) {
+          // Dry-run: just record what we WOULD do.
+          audit.write({
+            event: 'would-reencrypt',
+            id: row.id,
+            format,
+            hasPrefix: newEncrypted.startsWith('aes256gcm:v1:'),
+          });
+          // Drop the reference so GC can reclaim the prior plaintext.
+          plaintext = '';
+          continue;
+        }
+
+        // Optimistic concurrency: only rewrite if the row still holds the
+        // exact ciphertext we read. A concurrent claim will have re-encrypted
+        // it; if so, we skip rather than overwrite.
+        const updateResult: UpdateResult = await dataSource
+          .getRepository(Account)
+          .update(
+            { id: row.id, secretKeyEncrypted: stored },
+            { secretKeyEncrypted: newEncrypted },
+          );
+        const affected = updateResult.affected ?? 0;
+        if (affected === 1) {
+          report.reencrypted += 1;
+          audit.write({ event: 'reencrypted', id: row.id, format });
+        } else {
+          report.skippedConcurrent += 1;
+          audit.write({
+            event: 'skipped-concurrent',
+            id: row.id,
+            format,
+            reason: 'optimistic-concurrency-lost',
+          });
+        }
+        // Drop the reference so GC can reclaim the decrypted plaintext.
+        plaintext = '';
+      }
+
+      offset += batch.length;
+      if (batch.length < flags.batchSize) break;
+    }
+
+    audit.write({ event: 'complete', report });
+    return report;
+  } finally {
+    // Drain audit stream BEFORE closing Nest context so the file is
+    // fully flushed even if app.close() errors.
+    await audit.closeAsync();
+    await app.close();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Entry point — invoked when this file is the process entry, regardless of
+// whether it was reached as .ts (ts-node) or .js (compiled).
+// ---------------------------------------------------------------------------
+
+async function main(): Promise<void> {
+  const flags = parseCli(process.argv.slice(2));
+
+  if (flags.execute && !flags.hasBackup) {
+    process.stderr.write(
+      'FATAL: --execute requires --i-have-a-backup. Refusing to write.\n',
+    );
+    process.exit(2);
+  }
+
+  process.stdout.write(
+    `[migrate-secrets] mode=${flags.execute ? 'EXECUTE' : 'DRY-RUN'}\n` +
+      `[migrate-secrets] batch-size=${flags.batchSize}\n` +
+      `[migrate-secrets] audit-file=${flags.auditFile}\n`,
+  );
+
+  const report = await runMigration(flags);
+
+  process.stdout.write(
+    `\n[migrate-secrets] Report (${flags.execute ? 'EXECUTE' : 'DRY-RUN'}):\n` +
+      `  total-scanned       : ${report.totalScanned}\n` +
+      `  already-prefixed-v1 : ${report.prefixed}\n` +
+      `  unprefixed-aes      : ${report.unprefixedAes}\n` +
+      `  legacy-base64       : ${report.legacyBase64}\n` +
+      `  corrupt (halted)    : ${report.corrupt}\n` +
+      `  reencrypted         : ${report.reencrypted}\n` +
+      `  skipped-concurrent  : ${report.skippedConcurrent}\n` +
+      `  audit-file          : ${flags.auditFile}\n`,
+  );
+
+  // Dry-run hint; in execute mode, zero corrupt means a clean run.
+  if (!flags.execute) {
+    const wouldChange =
+      report.unprefixedAes + report.legacyBase64 - report.skippedConcurrent;
+    if (wouldChange > 0) {
+      process.stdout.write(
+        `\n[migrate-secrets] ${wouldChange} rows would be rewritten on --execute.\n`,
+      );
+    } else {
+      process.stdout.write(
+        `\n[migrate-secrets] No rows require rewriting. Database is current.\n`,
+      );
+    }
+  }
+}
+
+const ENTRY_RE = /migrate-secrets\.(ts|js)$/;
+const argv1 = process.argv[1];
+const isEntry = typeof argv1 === 'string' && ENTRY_RE.test(argv1);
+if (isEntry) {
+  main().catch((err: unknown) => {
+    const message = err instanceof Error ? err.message : String(err);
+    process.stderr.write(`FATAL: ${message}\n`);
+    if (err instanceof Error && err.stack) {
+      process.stderr.write(err.stack + '\n');
+    }
+    process.exit(1);
+  });
+}

--- a/src/scripts/migrate-secrets.ts
+++ b/src/scripts/migrate-secrets.ts
@@ -54,16 +54,12 @@ import { ConfigModule, ConfigService } from '@nestjs/config';
 import { TypeOrmModule, TypeOrmModuleOptions } from '@nestjs/typeorm';
 import { NestFactory } from '@nestjs/core';
 import { DataSource, UpdateResult } from 'typeorm';
-import * as path from 'path';
 
 import { parseCli, createAuditLogger, type CliFlags } from './migration-cli.js';
 import databaseConfig from '../config/database.config.js';
 import stellarConfig from '../config/stellar.config.js';
 import { Account } from '../modules/accounts/entities/account.entity.js';
-import {
-  SecretEncryptionUtil,
-  SecretFormat,
-} from '../common/crypto/secret-encryption.util.js';
+import { SecretEncryptionUtil } from '../common/crypto/secret-encryption.util.js';
 
 // ---------------------------------------------------------------------------
 // Migration module — minimal application context. Deliberately does NOT import

--- a/src/scripts/migration-cli.spec.ts
+++ b/src/scripts/migration-cli.spec.ts
@@ -83,8 +83,8 @@ describe('createAuditLogger', () => {
     const content = fs.readFileSync(file, 'utf8');
     const lines = content.trim().split('\n');
     expect(lines).toHaveLength(2);
-    const first = JSON.parse(lines[0] as string) as Record<string, unknown>;
-    const second = JSON.parse(lines[1] as string) as Record<string, unknown>;
+    const first = JSON.parse(lines[0]) as Record<string, unknown>;
+    const second = JSON.parse(lines[1]) as Record<string, unknown>;
     expect(first.event).toBe('start');
     expect(first.execute).toBe(false);
     expect(typeof first.time).toBe('string');

--- a/src/scripts/migration-cli.spec.ts
+++ b/src/scripts/migration-cli.spec.ts
@@ -1,0 +1,196 @@
+import * as crypto from 'crypto';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import { parseCli, createAuditLogger, type CliFlags } from './migration-cli.js';
+import { SecretEncryptionUtil } from '../common/crypto/secret-encryption.util.js';
+
+// ---------------------------------------------------------------------------
+// parseCli
+// ---------------------------------------------------------------------------
+
+describe('parseCli', () => {
+  it('defaults to dry-run with batchSize=500', () => {
+    const flags = parseCli([]);
+    expect(flags.execute).toBe(false);
+    expect(flags.hasBackup).toBe(false);
+    expect(flags.batchSize).toBe(500);
+    expect(flags.auditFile).toMatch(/secret-migration-.*\.ndjson$/);
+  });
+
+  it('parses --execute and --i-have-a-backup', () => {
+    const flags = parseCli(['--execute', '--i-have-a-backup']);
+    expect(flags.execute).toBe(true);
+    expect(flags.hasBackup).toBe(true);
+  });
+
+  it('parses --batch-size and clamps to [1, 10_000]', () => {
+    expect(parseCli(['--batch-size=42']).batchSize).toBe(42);
+    expect(parseCli(['--batch-size=0']).batchSize).toBe(500); // rejected, default
+    expect(parseCli(['--batch-size=20000']).batchSize).toBe(500); // clamp rejected
+    expect(parseCli(['--batch-size=-5']).batchSize).toBe(500); // negative rejected
+  });
+
+  it('parses --audit-file relative path', () => {
+    const flags = parseCli(['--audit-file=audit.ndjson']);
+    expect(flags.auditFile).toBe(path.resolve(process.cwd(), 'audit.ndjson'));
+  });
+
+  it('ignores unknown flags', () => {
+    const flags = parseCli(['--definitely-not-a-flag', '--execute']);
+    expect(flags.execute).toBe(true);
+    expect(flags.batchSize).toBe(500);
+  });
+
+  it('returned object satisfies CliFlags at the type level', () => {
+    const flags: CliFlags = parseCli([]);
+    expect(flags).toEqual(
+      expect.objectContaining({
+        execute: expect.any(Boolean),
+        hasBackup: expect.any(Boolean),
+        batchSize: expect.any(Number),
+        auditFile: expect.any(String),
+      }),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createAuditLogger (NDJSON writer)
+// ---------------------------------------------------------------------------
+
+describe('createAuditLogger', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'audit-test-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('creates the parent directory and writes valid NDJSON lines', async () => {
+    const nested = path.join(tmpDir, 'nested', 'sub');
+    const file = path.join(nested, 'audit.ndjson');
+    const audit = createAuditLogger(file);
+
+    audit.write({ event: 'start', execute: false });
+    audit.write({ event: 'a', id: 'row-1', format: 'legacy-base64' });
+    await audit.closeAsync();
+
+    const content = fs.readFileSync(file, 'utf8');
+    const lines = content.trim().split('\n');
+    expect(lines).toHaveLength(2);
+    const first = JSON.parse(lines[0] as string) as Record<string, unknown>;
+    const second = JSON.parse(lines[1] as string) as Record<string, unknown>;
+    expect(first.event).toBe('start');
+    expect(first.execute).toBe(false);
+    expect(typeof first.time).toBe('string');
+    expect(second.id).toBe('row-1');
+    expect(second.format).toBe('legacy-base64');
+  });
+
+  it('closeSync ends the stream and the file persists', () => {
+    const file = path.join(tmpDir, 'audit.ndjson');
+    const audit = createAuditLogger(file);
+    audit.write({ event: 'tick' });
+    audit.closeSync();
+    expect(fs.existsSync(file)).toBe(true);
+  });
+
+  it('closeAsync awaits the stream drain', async () => {
+    const file = path.join(tmpDir, 'audit.ndjson');
+    const audit = createAuditLogger(file);
+    for (let i = 0; i < 100; i += 1) {
+      audit.write({ event: 'tick', i });
+    }
+    await audit.closeAsync();
+    const content = fs.readFileSync(file, 'utf8');
+    const lines = content.trim().split('\n');
+    expect(lines).toHaveLength(100);
+  });
+
+  it('survives a nested parent directory that does not yet exist', () => {
+    const deepPath = path.join(tmpDir, 'a', 'b', 'c', 'audit.ndjson');
+    const audit = createAuditLogger(deepPath);
+    audit.write({ event: 'tick' });
+    audit.closeSync();
+    expect(fs.existsSync(deepPath)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Classifier invariants — what runMigration relies on
+// ---------------------------------------------------------------------------
+
+describe('classifier invariants used by runMigration', () => {
+  const validKey = crypto.randomBytes(32).toString('hex');
+  const plaintext = 'S-SECRET-FOR-MIGRATION-UNIT-TEST';
+
+  function buildUnprefixedAes(): string {
+    const key = Buffer.from(validKey, 'hex');
+    const iv = crypto.randomBytes(16);
+    const cipher = crypto.createCipheriv('aes-256-gcm', key, iv);
+    const ct = Buffer.concat([
+      cipher.update(plaintext, 'utf8'),
+      cipher.final(),
+    ]);
+    const tag = cipher.getAuthTag();
+    return [iv.toString('hex'), tag.toString('hex'), ct.toString('hex')].join(
+      ':',
+    );
+  }
+
+  function buildLegacyBase64(): string {
+    return Buffer.from(plaintext).toString('base64');
+  }
+
+  it.each([
+    ['v1-prefixed', () => SecretEncryptionUtil.encrypt(plaintext, validKey)],
+    ['unprefixed-aes', buildUnprefixedAes],
+    ['legacy-base64', buildLegacyBase64],
+  ] as const)(
+    'classifies %s into one of the four legal buckets',
+    (_label, make) => {
+      const stored = make();
+      const fmt = SecretEncryptionUtil.classify(stored);
+      expect([
+        'prefixed-aes-v1',
+        'unprefixed-aes',
+        'legacy-base64',
+        'corrupt',
+      ]).toContain(fmt);
+    },
+  );
+
+  it('round-trips a legacy base64 row through encrypt()', () => {
+    const stored = Buffer.from(plaintext).toString('base64');
+    const decoded = Buffer.from(stored, 'base64').toString('utf8');
+    const reencrypted = SecretEncryptionUtil.encrypt(decoded, validKey);
+    expect(SecretEncryptionUtil.decrypt(reencrypted, validKey)).toBe(plaintext);
+    expect(reencrypted.startsWith('aes256gcm:v1:')).toBe(true);
+  });
+
+  it('round-trips an unprefixed-AES row through decrypt() then encrypt()', () => {
+    const key = Buffer.from(validKey, 'hex');
+    const iv = crypto.randomBytes(16);
+    const cipher = crypto.createCipheriv('aes-256-gcm', key, iv);
+    const ct = Buffer.concat([
+      cipher.update(plaintext, 'utf8'),
+      cipher.final(),
+    ]);
+    const tag = cipher.getAuthTag();
+    const legacy = [
+      iv.toString('hex'),
+      tag.toString('hex'),
+      ct.toString('hex'),
+    ].join(':');
+
+    const decoded = SecretEncryptionUtil.decrypt(legacy, validKey);
+    const reencrypted = SecretEncryptionUtil.encrypt(decoded, validKey);
+    expect(SecretEncryptionUtil.decrypt(reencrypted, validKey)).toBe(plaintext);
+    expect(reencrypted.startsWith('aes256gcm:v1:')).toBe(true);
+  });
+});

--- a/src/scripts/migration-cli.ts
+++ b/src/scripts/migration-cli.ts
@@ -1,0 +1,120 @@
+/**
+ * migration-cli.ts
+ * ────────────────
+ * Pure, side-effect-free CLI helpers used by scripts/migrate-secrets.ts and
+ * its unit spec.
+ *
+ * This module deliberately imports ONLY:
+ *   - node:fs (NDJSON audit file)
+ *   - node:path (resolving --audit-file relative paths)
+ *
+ * No Nest, no TypeORM, no database config. Keeping the surface this small is
+ * what lets the unit spec assert against these helpers without transitively
+ * loading `database.config.ts`, which triggers a pre-existing
+ * `__filename` redeclaration under ts-jest's CommonJS transform. The mate
+ * runner script — `migrate-secrets.ts` — also imports from here so the
+ * responsibilities split cleanly: this file owns the I/O plumbing, the
+ * runner owns the data-source wiring and the per-row mutation.
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+
+export interface CliFlags {
+  execute: boolean;
+  hasBackup: boolean;
+  batchSize: number;
+  auditFile: string;
+}
+
+/**
+ * Lightweight argv parser — no new dep. Recognises:
+ *   --execute
+ *   --i-have-a-backup
+ *   --batch-size=N   (1 ≤ N ≤ 10_000, otherwise defaults to 500)
+ *   --audit-file=PATH
+ * Unknown flags are ignored; missing flags fall through to defaults.
+ */
+export function parseCli(argv: readonly string[]): CliFlags {
+  const flags: CliFlags = {
+    execute: false,
+    hasBackup: false,
+    batchSize: 500,
+    auditFile: path.resolve(
+      process.cwd(),
+      `secret-migration-${new Date().toISOString().replace(/[:.]/g, '-')}.ndjson`,
+    ),
+  };
+  for (const arg of argv) {
+    if (arg === '--execute') flags.execute = true;
+    else if (arg === '--i-have-a-backup') flags.hasBackup = true;
+    else if (arg.startsWith('--batch-size=')) {
+      const n = parseInt(arg.split('=')[1] ?? '', 10);
+      if (Number.isFinite(n) && n > 0 && n <= 10_000) {
+        flags.batchSize = n;
+      }
+    } else if (arg.startsWith('--audit-file=')) {
+      const v = arg.split('=')[1];
+      if (v) flags.auditFile = path.resolve(process.cwd(), v);
+    }
+  }
+  return flags;
+}
+
+export interface AuditLogger {
+  write(entry: Record<string, unknown>): void;
+  closeSync(): void;
+  closeAsync(): Promise<void>;
+}
+
+/**
+ * Creates an NDJSON audit writer at `filePath`. The parent directory is
+ * created if missing. Each `write()` prepends an ISO-8601 timestamp before
+ * the caller's fields so consumers can re-construct the run timeline
+ * without trusting caller-supplied `time` keys.
+ *
+ * Implementation note — sync on purpose
+ * ──────────────────────────────────────
+ * We use `fs.openSync`/`fs.writeSync`/`fs.closeSync` rather than the
+ * `fs.createWriteStream` async stream. Reason: `createWriteStream` opens
+ * via an async syscall, so callers that `write()` then `closeSync()` in
+ * tight succession race against the open — manifest as ENOENT on the
+ * write, or the file not yet existing on disk by the time the test
+ * asserts. Synchronous ops remove that race entirely; performance is
+ * ample for a single-writer NDJSON audit trail (short lines, low rate,
+ * sequential calls from the migration's serial row loop).
+ *
+ * `closeAsync()` returns a resolved Promise so callers can `await` it
+ * inside a `finally {}` block. Because the underlying close is already
+ * synchronous, the promise resolves on the next microtask tick.
+ */
+export function createAuditLogger(filePath: string): AuditLogger {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  const fd = fs.openSync(filePath, 'a');
+  let closed = false;
+
+  const closeFd = (): void => {
+    if (closed) return;
+    closed = true;
+    fs.closeSync(fd);
+  };
+
+  return {
+    write(entry) {
+      if (closed) {
+        throw new Error(
+          'AuditLogger: cannot write after close. ' +
+            'Open a fresh logger for additional entries.',
+        );
+      }
+      const line =
+        JSON.stringify({ time: new Date().toISOString(), ...entry }) + '\n';
+      fs.writeSync(fd, line);
+    },
+    closeSync() {
+      closeFd();
+    },
+    async closeAsync() {
+      closeFd();
+    },
+  };
+}

--- a/src/scripts/migration-cli.ts
+++ b/src/scripts/migration-cli.ts
@@ -113,8 +113,13 @@ export function createAuditLogger(filePath: string): AuditLogger {
     closeSync() {
       closeFd();
     },
-    async closeAsync() {
+    closeAsync(): Promise<void> {
       closeFd();
+      // Underlying I/O is already synchronous; return a resolved promise so
+      // callers can `await` this inside a `finally {}` block for unified
+      // shutdown sequencing regardless of whether the file was actually
+      // written to. Resolves on the next microtask tick.
+      return Promise.resolve();
     },
   };
 }

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,4 +1,4 @@
 {
   "extends": "./tsconfig.json",
-  "exclude": ["node_modules", "test", "dist", "**/*spec.ts"]
+  "exclude": ["node_modules", "test", "dist", "**/*spec.ts", "src/scripts/**"]
 }


### PR DESCRIPTION
## Changes
- `SecretEncryptionUtil.encrypt` now emits `aes256gcm:v1:<iv>:<authTag>:<data>` on every write.
- `SecretEncryptionUtil.decrypt` accepts both v1-prefixed AND unprefixed-3-hex rows during the migration window, rejects `aes256gcm:v2+`/`v0` loudly so future formats never silently mis-decode, and rejects naked base64 with a message pointing at the migration script.
- New pure helper `SecretEncryptionUtil.classify(encrypted)` exported for the migration script and its spec (returns one of `prefixed-aes-v1`, `unprefixed-aes`, `legacy-base64`, `corrupt`).
- New `src/scripts/migration-cli.ts` (parseCli + NDJSON AuditLogger using sync `fs.openSync`/`writeSync`/`closeSync` so the unit spec is race-free). Imports ONLY `fs` and `path` so `migration-cli.spec.ts` never transitively loads `database.config.ts`.
- New `src/scripts/migrate-secrets.ts`: `NestFactory.createApplicationContext` against a minimal `MigrationModule` — deliberately does NOT import `AppModule` to avoid `ScheduleModule.forRoot()` firing cron jobs during the run. Default dry-run; `--i-have-a-backup` required for writes. Per-row `Repository.update(...)` keyed by optimistic `WHERE secretKeyEncrypted = :old` so a concurrent claim redemption can never be clobbered. Halt on any `corrupt` row (zero tolerance — bad rows mean permanently locked funds). NDJSON audit stream is awaited-drained before `app.close()`.
- `tsconfig.build.json` excludes `src/scripts/**` so production HTTP build does not pull the migration CLI.
- `package.json` adds `npm run migrate:secrets` wrapper.
- `src/modules/accounts/accounts.service.ts` docstring: replaced the misleading "base64 for storage (NOT SECURE)" note with an accurate AES-256-GCM description and a pointer to the migration command.

## Testing
- Encrypted-unit spec: 19/19 pass — round-trip, random IV, prefix presence, `aes256gcm:v2`/`v0` rejection, unprefixed-AES acceptance, base64 error message, classify buckets, key validation.
- Migration CLI spec: 15/15 pass — `parseCli` defaults/sentinels, AuditLogger sync + async-drain + nested Mkdir, classifier invariants on every source format.
- `npx tsc --noEmit -p tsconfig.json` clean for all touched files.
- `npx tsc --noEmit -p tsconfig.build.json` clean (confirms `src/scripts/**` stays out of the build).
- `npx prettier --check` clean for all touched files.
- `npx eslint` 5 errors / 8 warnings on touched files (down from 11 errors before this PR) — the remaining errors are on adjacent existing files unchanged by this PR.

## Operational notes (read BEFORE running on production)
- **Run DRY-RUN first** (`npm run migrate:secrets`) and inspect the resulting `secret-migration-<ts>.ndjson` audit file. The report includes a `would-change` count.
- **Take a DB snapshot** before executing with `--execute`. The script will refuse to write without `--i-have-a-backup` for exactly this reason.
- Each UPDATE is optimistic-concurrency-guarded, so a live claim redemption racing the same row will produce a `skipped-concurrent` audit entry (the live service has the up-to-date value). No silent clobber.
- Key rotation is out of scope for this PR (encrypt handles format, not the dual-key path).

Closes #193
Closes #170 