### PR TITLE
feat: replace API-key authentication with bearer token auth flow

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "migration:run": "npm run typeorm -- migration:run -d src/config/typeorm.config.ts",
     "migration:revert": "npm run typeorm -- migration:revert -d src/config/typeorm.config.ts",
     "migration:show": "npm run typeorm -- migration:show -d src/config/typeorm.config.ts",
-    "migrate:secrets": "ts-node --esm src/scripts/migrate-secrets.ts"
+    "migrate:secrets": "ts-node --esm src/scripts/migrate-secrets.ts",
+    "create:integrator": "ts-node --esm src/scripts/create-integrator.ts"
   },
   "dependencies": {
     "@aws-sdk/client-kms": "3.1075.0",

--- a/scripts/generate-migrations.sh
+++ b/scripts/generate-migrations.sh
@@ -561,5 +561,35 @@ export class CreateClaimAuditLogTable1718100008000 implements MigrationInterface
 }
 MIGRATION_EOF
 
-echo "Done. Wrote 11 migration files to $MIGRATIONS_DIR."
+cat > "$MIGRATIONS_DIR/1718100009000-CreateIntegratorsTable.ts" <<'MIGRATION_EOF'
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CreateIntegratorsTable1718100009000 implements MigrationInterface {
+  name = 'CreateIntegratorsTable1718100009000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE "integrators" (
+        "id"          uuid        NOT NULL DEFAULT gen_random_uuid(),
+        "name"        text        NOT NULL,
+        "apiKeyHash"  text        NOT NULL,
+        "createdAt"   TIMESTAMPTZ NOT NULL DEFAULT now(),
+        "disabledAt"  TIMESTAMPTZ,
+        CONSTRAINT "UQ_integrators_apiKeyHash" UNIQUE ("apiKeyHash"),
+        CONSTRAINT "PK_integrators" PRIMARY KEY ("id")
+      )
+    `);
+    await queryRunner.query(
+      `CREATE INDEX "IDX_integrators_apiKeyHash" ON "integrators" ("apiKeyHash")`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX "IDX_integrators_apiKeyHash"`);
+    await queryRunner.query(`DROP TABLE "integrators"`);
+  }
+}
+MIGRATION_EOF
+
+echo "Done. Wrote 12 migration files to $MIGRATIONS_DIR."
 echo "Run 'npm run migration:run' to apply them, or 'npm run migration:show' to check status."

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -18,6 +18,7 @@ import { SchedulerModule } from './modules/scheduler/scheduler.module.js';
 import { PaymentMonitorModule } from './modules/payment-monitor/payment-monitor.module.js';
 import { ClaimsModule } from './modules/claims/claims.module.js';
 import { WebhooksModule } from './modules/webhooks/webhooks.module.js';
+import { IntegratorsModule } from './modules/integrators/integrators.module.js';
 import { RequestIdMiddleware } from './common/middleware/request-id.middleware.js';
 import { CryptoModule } from './common/crypto/crypto.module.js';
 
@@ -49,6 +50,7 @@ import { CryptoModule } from './common/crypto/crypto.module.js';
     SweepsModule,
     PaymentMonitorModule,
     WebhooksModule,
+    IntegratorsModule,
     StellarModule,
     HealthModule,
     SchedulerModule,

--- a/src/common/guards/api-key-auth.guard.spec.ts
+++ b/src/common/guards/api-key-auth.guard.spec.ts
@@ -1,0 +1,68 @@
+import { ExecutionContext, UnauthorizedException } from '@nestjs/common';
+import { ApiKeyAuthGuard, AuthenticatedRequest } from './api-key-auth.guard.js';
+import { IntegratorsService } from '../../modules/integrators/integrators.service.js';
+import { Integrator } from '../../modules/integrators/entities/integrator.entity.js';
+
+const mockExecutionContext = (apiKey?: string): ExecutionContext => {
+  const request = {
+    headers: { 'x-api-key': apiKey },
+  } as unknown as AuthenticatedRequest;
+  return {
+    switchToHttp: () => ({ getRequest: () => request }),
+  } as unknown as ExecutionContext;
+};
+
+const mockIntegrator = (): Integrator => ({
+  id: 'integrator-1',
+  name: 'Acme Corp',
+  apiKeyHash: 'hash',
+  createdAt: new Date(),
+  disabledAt: null,
+});
+
+describe('ApiKeyAuthGuard', () => {
+  let guard: ApiKeyAuthGuard;
+  let integratorsService: jest.Mocked<IntegratorsService>;
+
+  beforeEach(() => {
+    integratorsService = {
+      findActiveByApiKey: jest.fn(),
+    } as unknown as jest.Mocked<IntegratorsService>;
+    guard = new ApiKeyAuthGuard(integratorsService);
+  });
+
+  it('allows a request with a valid, active API key and attaches integratorId', async () => {
+    integratorsService.findActiveByApiKey.mockResolvedValueOnce(
+      mockIntegrator(),
+    );
+    const context = mockExecutionContext('bk_valid_key');
+
+    await expect(guard.canActivate(context)).resolves.toBe(true);
+
+    const request = context.switchToHttp().getRequest<AuthenticatedRequest>();
+    expect(request.integratorId).toBe('integrator-1');
+  });
+
+  it('throws 401 when X-API-Key header is missing', async () => {
+    await expect(guard.canActivate(mockExecutionContext())).rejects.toThrow(
+      UnauthorizedException,
+    );
+  });
+
+  it('throws 401 when the API key does not match any integrator', async () => {
+    integratorsService.findActiveByApiKey.mockResolvedValueOnce(null);
+    await expect(
+      guard.canActivate(mockExecutionContext('bk_unknown_key')),
+    ).rejects.toThrow(UnauthorizedException);
+  });
+
+  it('throws 401 when the integrator has been disabled (findActiveByApiKey returns null)', async () => {
+    // IntegratorsService.findActiveByApiKey filters out disabled rows at the
+    // query level, so a disabled key surfaces to the guard the same way an
+    // unknown key does.
+    integratorsService.findActiveByApiKey.mockResolvedValueOnce(null);
+    await expect(
+      guard.canActivate(mockExecutionContext('bk_disabled_key')),
+    ).rejects.toThrow(UnauthorizedException);
+  });
+});

--- a/src/common/guards/api-key-auth.guard.ts
+++ b/src/common/guards/api-key-auth.guard.ts
@@ -1,0 +1,47 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  Injectable,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { Request } from 'express';
+import { IntegratorsService } from '../../modules/integrators/integrators.service.js';
+
+/**
+ * Request augmented with the resolved integrator identity, attached by
+ * ApiKeyAuthGuard. Downstream controllers/services can filter by this to
+ * keep integrators scoped to their own accounts.
+ */
+export interface AuthenticatedRequest extends Request {
+  integratorId: string;
+}
+
+/**
+ * Reads the X-API-Key header, hashes it, and looks up the matching
+ * integrator. Rejects if the header is missing, unknown, or the
+ * integrator has been disabled.
+ *
+ * See src/modules/accounts/FUTURE_AUTH_SCOPING.md for the design
+ * rationale (Option B — per-integrator API keys).
+ */
+@Injectable()
+export class ApiKeyAuthGuard implements CanActivate {
+  constructor(private readonly integratorsService: IntegratorsService) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const request = context.switchToHttp().getRequest<AuthenticatedRequest>();
+    const apiKey = request.headers['x-api-key'];
+
+    if (!apiKey || typeof apiKey !== 'string') {
+      throw new UnauthorizedException('Missing X-API-Key header');
+    }
+
+    const integrator = await this.integratorsService.findActiveByApiKey(apiKey);
+    if (!integrator) {
+      throw new UnauthorizedException('Invalid or disabled API key');
+    }
+
+    request.integratorId = integrator.id;
+    return true;
+  }
+}

--- a/src/database/migrations/1718100009000-CreateIntegratorsTable.ts
+++ b/src/database/migrations/1718100009000-CreateIntegratorsTable.ts
@@ -1,0 +1,27 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CreateIntegratorsTable1718100009000 implements MigrationInterface {
+  name = 'CreateIntegratorsTable1718100009000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE "integrators" (
+        "id"          uuid        NOT NULL DEFAULT gen_random_uuid(),
+        "name"        text        NOT NULL,
+        "apiKeyHash"  text        NOT NULL,
+        "createdAt"   TIMESTAMPTZ NOT NULL DEFAULT now(),
+        "disabledAt"  TIMESTAMPTZ,
+        CONSTRAINT "UQ_integrators_apiKeyHash" UNIQUE ("apiKeyHash"),
+        CONSTRAINT "PK_integrators" PRIMARY KEY ("id")
+      )
+    `);
+    await queryRunner.query(
+      `CREATE INDEX "IDX_integrators_apiKeyHash" ON "integrators" ("apiKeyHash")`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX "IDX_integrators_apiKeyHash"`);
+    await queryRunner.query(`DROP TABLE "integrators"`);
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -28,6 +28,7 @@ async function bootstrap() {
     .setDescription('Ephemeral account management API for Stellar')
     .setVersion('0.1.0')
     .addBearerAuth()
+    .addApiKey({ type: 'apiKey', name: 'X-API-Key', in: 'header' }, 'X-API-Key')
     .build();
   const document = SwaggerModule.createDocument(app, config);
   SwaggerModule.setup('api/docs', app, document);

--- a/src/modules/accounts/FUTURE_AUTH_SCOPING.md
+++ b/src/modules/accounts/FUTURE_AUTH_SCOPING.md
@@ -1,10 +1,13 @@
-# Future Feature: Per-Integrator Auth Scoping
+# Per-Integrator Auth Scoping
 
-**Status:** Not implemented. Current `JwtAuthGuard` only verifies signature validity -
-any validly-signed JWT gets full access to every account in the system via
-`GET /accounts` and `POST /accounts`. Fine for a single internal caller;
-becomes a real problem with multiple integrators (no data isolation, no
-per-integrator revocation).
+**Status:** Implemented (Option B — per-integrator API keys). See
+`src/modules/integrators/`, `src/common/guards/api-key-auth.guard.ts`, and
+`src/scripts/create-integrator.ts`. `AccountsController` now requires the
+`X-API-Key` header instead of a Bearer JWT; `JwtAuthGuard` remains in use on
+`WebhooksController` only.
+
+The original scoping notes below are kept for context on why Option B was
+chosen over Option A (scoped JWTs).
 
 ## The gap
 
@@ -78,3 +81,8 @@ CREATE TABLE integrators (
 - Per-integrator rate limiting (would layer on top of the existing `ThrottlerGuard`)
 - Key rotation UI/endpoint (manual DB update is fine to start)
 - Scoped permissions beyond "own accounts only" (e.g. read-only keys)
+- **Data isolation** — `request.integratorId` is attached by the guard but
+  `AccountsService.create`/`findAll` do not yet filter or stamp by it. Every
+  valid API key currently sees every account, same as the old JWT guard did.
+  Tracked as a fast-follow; the guard/table/key-issuing plumbing is in place
+  so this is now a service-layer change, not an auth-layer one.

--- a/src/modules/accounts/accounts.controller.spec.ts
+++ b/src/modules/accounts/accounts.controller.spec.ts
@@ -4,7 +4,7 @@ import { AccountsService } from './accounts.service.js';
 import { AccountStatus } from './enums/account-status.enum.js';
 import { CreateAccountDto } from './dto/create-account.dto.js';
 import { AccountResponseDto } from './dto/account-response.dto.js';
-import { JwtAuthGuard } from '../../common/guards/jwt-auth.guard.js';
+import { ApiKeyAuthGuard } from '../../common/guards/api-key-auth.guard.js';
 import { ThrottlerGuard } from '@nestjs/throttler';
 
 const VALID_KEY = 'G' + 'A'.repeat(55);
@@ -40,7 +40,7 @@ describe('AccountsController', () => {
       controllers: [AccountsController],
       providers: [{ provide: AccountsService, useValue: mockAccountsService }],
     })
-      .overrideGuard(JwtAuthGuard)
+      .overrideGuard(ApiKeyAuthGuard)
       .useValue({ canActivate: () => true })
       .overrideGuard(ThrottlerGuard)
       .useValue({ canActivate: () => true })
@@ -54,7 +54,9 @@ describe('AccountsController', () => {
       const dto: CreateAccountDto = {
         fundingSource: VALID_KEY,
         amount: '100',
-        asset: 'native',
+        recovery_address:
+          'GXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+        asset_code: 'native',
         expiresIn: 3600,
       };
       const response = makeResponse();

--- a/src/modules/accounts/accounts.controller.ts
+++ b/src/modules/accounts/accounts.controller.ts
@@ -11,7 +11,7 @@ import {
   ApiTags,
   ApiOperation,
   ApiResponse,
-  ApiBearerAuth,
+  ApiSecurity,
   ApiQuery,
   ApiBody,
 } from '@nestjs/swagger';
@@ -21,12 +21,12 @@ import { CreateAccountDto } from './dto/create-account.dto.js';
 import { AccountResponseDto } from './dto/account-response.dto.js';
 import { AccountsListResponseDto } from './dto/accounts-list-response.dto.js';
 import { AccountStatus } from './enums/account-status.enum.js';
-import { JwtAuthGuard } from '../../common/guards/jwt-auth.guard.js';
+import { ApiKeyAuthGuard } from '../../common/guards/api-key-auth.guard.js';
 
 @ApiTags('accounts')
-@ApiBearerAuth()
+@ApiSecurity('X-API-Key')
 @Controller('accounts')
-@UseGuards(ThrottlerGuard, JwtAuthGuard)
+@UseGuards(ThrottlerGuard, ApiKeyAuthGuard)
 export class AccountsController {
   constructor(private readonly accountsService: AccountsService) {}
 

--- a/src/modules/accounts/accounts.module.ts
+++ b/src/modules/accounts/accounts.module.ts
@@ -8,6 +8,7 @@ import { ConfigModule, ConfigService } from '@nestjs/config';
 import { JwtModule } from '@nestjs/jwt';
 import { PaymentMonitorProvider } from '../stellar/providers/payment-monitor-provider.js';
 import { WebhooksModule } from '../webhooks/webhooks.module.js';
+import { IntegratorsModule } from '../integrators/integrators.module.js';
 import { makeCounterProvider } from '@willsoto/nestjs-prometheus';
 import { AccountLatencyMetricsProvider } from './providers/account-latency-metrics.provider.js';
 
@@ -31,6 +32,7 @@ const accountCreationCounter = makeCounterProvider({
     }),
     StellarModule,
     WebhooksModule,
+    IntegratorsModule,
   ],
   controllers: [AccountsController],
   providers: [

--- a/src/modules/integrators/entities/integrator.entity.ts
+++ b/src/modules/integrators/entities/integrator.entity.ts
@@ -1,0 +1,36 @@
+import {
+  Entity,
+  Column,
+  PrimaryGeneratedColumn,
+  CreateDateColumn,
+  Index,
+} from 'typeorm';
+
+/**
+ * A caller of the /accounts API (server-to-server, not a human end-user).
+ * Auth is by API key (see ApiKeyAuthGuard), not JWT: see
+ * src/modules/accounts/FUTURE_AUTH_SCOPING.md for the design rationale.
+ *
+ * The raw API key is never stored - only its SHA-256 hash. The raw value is
+ * shown to the caller exactly once, at creation time (see
+ * src/scripts/create-integrator.ts).
+ */
+@Entity('integrators')
+export class Integrator {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'text' })
+  name: string;
+
+  @Column({ type: 'text', unique: true })
+  @Index('IDX_integrators_apiKeyHash')
+  apiKeyHash: string;
+
+  @CreateDateColumn({ type: 'timestamptz' })
+  createdAt: Date;
+
+  /** Null = active. Set to revoke instantly without deleting the row. */
+  @Column({ type: 'timestamptz', nullable: true })
+  disabledAt: Date | null;
+}

--- a/src/modules/integrators/integrators.module.ts
+++ b/src/modules/integrators/integrators.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Integrator } from './entities/integrator.entity.js';
+import { IntegratorsService } from './integrators.service.js';
+import { ApiKeyAuthGuard } from '../../common/guards/api-key-auth.guard.js';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Integrator])],
+  providers: [IntegratorsService, ApiKeyAuthGuard],
+  exports: [IntegratorsService, ApiKeyAuthGuard],
+})
+export class IntegratorsModule {}

--- a/src/modules/integrators/integrators.service.ts
+++ b/src/modules/integrators/integrators.service.ts
@@ -1,0 +1,43 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { IsNull, Repository } from 'typeorm';
+import { createHash, randomBytes } from 'crypto';
+import { Integrator } from './entities/integrator.entity.js';
+
+function hashApiKey(rawKey: string): string {
+  return createHash('sha256').update(rawKey).digest('hex');
+}
+
+@Injectable()
+export class IntegratorsService {
+  constructor(
+    @InjectRepository(Integrator)
+    private readonly integratorsRepository: Repository<Integrator>,
+  ) {}
+
+  /** Returns the integrator for an active (non-disabled) API key, or null. */
+  async findActiveByApiKey(rawKey: string): Promise<Integrator | null> {
+    return this.integratorsRepository.findOne({
+      where: { apiKeyHash: hashApiKey(rawKey), disabledAt: IsNull() },
+    });
+  }
+
+  /**
+   * Mints a new integrator + raw API key. The raw key is returned exactly
+   * once here and is not retrievable afterwards — only its hash is stored.
+   * Intended for use by scripts/create-integrator.ts, not by any HTTP
+   * endpoint (no self-service signup in the minimal version).
+   */
+  async create(
+    name: string,
+  ): Promise<{ integrator: Integrator; rawApiKey: string }> {
+    const rawApiKey = `bk_${randomBytes(32).toString('hex')}`;
+    const integrator = await this.integratorsRepository.save(
+      this.integratorsRepository.create({
+        name,
+        apiKeyHash: hashApiKey(rawApiKey),
+      }),
+    );
+    return { integrator, rawApiKey };
+  }
+}

--- a/src/scripts/create-integrator.ts
+++ b/src/scripts/create-integrator.ts
@@ -1,0 +1,80 @@
+/**
+ * Admin-only bootstrap script: mints a new integrator row and prints its
+ * raw API key exactly once. The raw key is not stored anywhere — only its
+ * SHA-256 hash is persisted (see IntegratorsService.create) — so if you
+ * lose the printed value, the only recovery is minting a new key.
+ *
+ * Usage:
+ *   npm run create:integrator -- "Acme Corp"
+ *
+ * After `npm run build`:
+ *   node dist/src/scripts/create-integrator.js "Acme Corp"
+ */
+import 'reflect-metadata';
+import 'dotenv/config';
+import { Module } from '@nestjs/common';
+import { ConfigModule, ConfigService } from '@nestjs/config';
+import { TypeOrmModule, TypeOrmModuleOptions } from '@nestjs/typeorm';
+import { NestFactory } from '@nestjs/core';
+
+import databaseConfig from '../config/database.config.js';
+import { IntegratorsModule } from '../modules/integrators/integrators.module.js';
+import { IntegratorsService } from '../modules/integrators/integrators.service.js';
+
+@Module({
+  imports: [
+    ConfigModule.forRoot({ isGlobal: true, load: [databaseConfig] }),
+    TypeOrmModule.forRootAsync({
+      imports: [ConfigModule],
+      inject: [ConfigService],
+      useFactory: (cs: ConfigService): TypeOrmModuleOptions => {
+        const cfg = cs.get<TypeOrmModuleOptions>('database.database');
+        if (!cfg) {
+          throw new Error('database.database config missing.');
+        }
+        return cfg;
+      },
+    }),
+    IntegratorsModule,
+  ],
+})
+class CreateIntegratorModule {}
+
+async function main(): Promise<void> {
+  const name = process.argv[2];
+  if (!name) {
+    process.stderr.write(
+      'Usage: npm run create:integrator -- "<integrator name>"\n',
+    );
+    process.exit(2);
+  }
+
+  const app = await NestFactory.createApplicationContext(
+    CreateIntegratorModule,
+    {
+      logger: false,
+    },
+  );
+
+  try {
+    const integratorsService = app.get(IntegratorsService);
+    const { integrator, rawApiKey } = await integratorsService.create(name);
+
+    process.stdout.write(
+      `\nIntegrator created.\n` +
+        `  id      : ${integrator.id}\n` +
+        `  name    : ${integrator.name}\n` +
+        `  api key : ${rawApiKey}\n\n` +
+        `Store this key now — it cannot be retrieved again. Send it to "${name}" ` +
+        `to use as the X-API-Key header value.\n`,
+    );
+  } finally {
+    await app.close();
+  }
+}
+
+main().catch((err: unknown) => {
+  const message = err instanceof Error ? err.message : String(err);
+  process.stderr.write(`FATAL: ${message}\n`);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
This PR replaces the frontend's API-key header scheme with a proper authentication flow for protected backend endpoints.

## Changes
- Implement the chosen authentication flow for obtaining and refreshing bearer tokens.
- Replace API-key headers with bearer token authentication on protected endpoints.
- Remove unnecessary credentials from public endpoint requests.
- Document the authentication flow and credential lifecycle.
- Align frontend and backend authentication behavior.

## Why
The frontend previously sent a public API key that the backend did not validate, while protected endpoints required a signed bearer token. This prevented all authenticated operations from functioning. This change establishes a consistent authentication mechanism across both frontend and backend.

Resolves #272