### PR TITLE
Feat/212-213-215-218-improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,11 @@
   "type": "module",
   "private": true,
   "license": "UNLICENSED",
+  "engines": {
+    "node": ">=20.0.0",
+    "npm": ">=10.0.0"
+  },
+  "_comment_stellar_sdk": "Pinned to 14.4.3 (no caret) — see docs/stellar-sdk-version.md",
   "scripts": {
     "build": "nest build",
     "format:check": "prettier --check .",
@@ -44,7 +49,7 @@
     "@opentelemetry/auto-instrumentations-node": "0.77.0",
     "@opentelemetry/exporter-trace-otlp-grpc": "0.219.0",
     "@opentelemetry/sdk-node": "0.219.0",
-    "@stellar/stellar-sdk": "^14.4.3",
+    "@stellar/stellar-sdk": "14.4.3",
     "@willsoto/nestjs-prometheus": "^6.1.0",
     "axios": "^1.13.2",
     "bcrypt": "^6.0.0",

--- a/src/modules/stellar/stellar.service.spec.ts
+++ b/src/modules/stellar/stellar.service.spec.ts
@@ -80,6 +80,9 @@ describe('StellarService', () => {
 
     service = module.get<StellarService>(StellarService);
 
+    // Trigger OnModuleInit to set internal state (network, URL validation)
+    service.onModuleInit();
+
     // Replace internal SDK server references with our controlled mocks
     (service as unknown as { server: unknown; sorobanServer: unknown }).server =
       horizonServer;
@@ -340,7 +343,7 @@ describe('StellarService', () => {
       });
 
       await expect(service.executeSweep(params)).rejects.toThrow(
-        'ALREADY_SWEPT',
+        'This account has already been swept.',
       );
     });
 
@@ -356,7 +359,7 @@ describe('StellarService', () => {
       });
 
       await expect(service.executeSweep(params)).rejects.toThrow(
-        'ACCOUNT_EXPIRED',
+        'This account has expired and can no longer be used.',
       );
     });
 
@@ -372,7 +375,7 @@ describe('StellarService', () => {
       });
 
       await expect(service.executeSweep(params)).rejects.toThrow(
-        'execute_sweep failed',
+        'An unexpected contract error occurred',
       );
     });
   });
@@ -439,7 +442,7 @@ describe('StellarService', () => {
       });
 
       await expect(service.expireAccount(params)).rejects.toThrow(
-        'ACCOUNT_ALREADY_TERMINAL',
+        'The account is in a terminal state and cannot be modified.',
       );
     });
 
@@ -458,7 +461,7 @@ describe('StellarService', () => {
       });
 
       await expect(service.expireAccount(params)).rejects.toThrow(
-        'expire() failed',
+        'An unexpected contract error occurred',
       );
     });
   });
@@ -610,6 +613,7 @@ describe('StellarService', () => {
       }).compile();
 
       const mainnetService = mainnetModule.get<StellarService>(StellarService);
+      mainnetService.onModuleInit();
       type InternalService = {
         network: string;
         getNetworkPassphrase: () => string;

--- a/src/modules/stellar/stellar.service.ts
+++ b/src/modules/stellar/stellar.service.ts
@@ -4,7 +4,7 @@ import * as StellarSdk from '@stellar/stellar-sdk';
 import { rpc as SorobanRpc } from '@stellar/stellar-sdk';
 import { InjectMetric } from '@willsoto/nestjs-prometheus';
 import { Histogram } from 'prom-client';
-import { throwContractError } from '../../common/errors/contract-error.mapper';
+import { throwContractError } from '../../common/errors/contract-error.mapper.js';
 
 export const EXPIRY_BUFFER_LEDGERS = 10;
 
@@ -47,8 +47,11 @@ export class StellarService implements OnModuleInit {
     }
     this.network = network as ValidNetwork;
 
-    const horizonUrl = this.configService.getOrThrow<string>('stellar.horizonUrl');
-    const sorobanRpcUrl = this.configService.getOrThrow<string>('stellar.sorobanRpcUrl');
+    const horizonUrl =
+      this.configService.getOrThrow<string>('stellar.horizonUrl');
+    const sorobanRpcUrl = this.configService.getOrThrow<string>(
+      'stellar.sorobanRpcUrl',
+    );
 
     // Warn if URLs look like they belong to the wrong network
     const isTestnetUrl =

--- a/src/modules/stellar/stellar.service.ts
+++ b/src/modules/stellar/stellar.service.ts
@@ -1,45 +1,101 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import * as StellarSdk from '@stellar/stellar-sdk';
 import { rpc as SorobanRpc } from '@stellar/stellar-sdk';
 import { InjectMetric } from '@willsoto/nestjs-prometheus';
 import { Histogram } from 'prom-client';
+import { throwContractError } from '../../common/errors/contract-error.mapper';
 
 export const EXPIRY_BUFFER_LEDGERS = 10;
 
+/** Valid network identifiers accepted by the configuration. */
+const VALID_NETWORKS = ['testnet', 'mainnet'] as const;
+type ValidNetwork = (typeof VALID_NETWORKS)[number];
+
 @Injectable()
-export class StellarService {
+export class StellarService implements OnModuleInit {
   private readonly logger = new Logger(StellarService.name);
   private server: StellarSdk.Horizon.Server;
   private sorobanServer: SorobanRpc.Server;
-  private network: string;
+  private network: ValidNetwork;
+
+  // --- Ledger cache (#218) ---
+  private cachedLedger: number | null = null;
+  private cachedLedgerAt: number = 0;
+  /** Cache the ledger sequence for 10 seconds to avoid redundant Horizon calls. */
+  private static readonly LEDGER_CACHE_TTL_MS = 10_000;
 
   constructor(
     private configService: ConfigService,
     @InjectMetric('soroban_rpc_latency_seconds')
     private readonly sorobanRpcLatency: Histogram<string>,
-  ) {
-    const horizonUrl =
-      this.configService.getOrThrow<string>('stellar.horizonUrl');
-    const sorobanRpcUrl = this.configService.getOrThrow<string>(
-      'stellar.sorobanRpcUrl',
-    );
-    this.network = this.configService.getOrThrow<string>('stellar.network');
+  ) {}
+
+  /**
+   * Validate stellar configuration on startup (#212).
+   * Ensures the network value is valid and the Horizon / Soroban RPC URLs
+   * are consistent with the chosen network.
+   */
+  onModuleInit(): void {
+    const networkRaw = this.configService.getOrThrow<string>('stellar.network');
+    const network = networkRaw.toLowerCase().trim();
+
+    if (!(VALID_NETWORKS as readonly string[]).includes(network)) {
+      throw new Error(
+        `Invalid STELLAR_NETWORK "${networkRaw}". Must be one of: ${VALID_NETWORKS.join(', ')}`,
+      );
+    }
+    this.network = network as ValidNetwork;
+
+    const horizonUrl = this.configService.getOrThrow<string>('stellar.horizonUrl');
+    const sorobanRpcUrl = this.configService.getOrThrow<string>('stellar.sorobanRpcUrl');
+
+    // Warn if URLs look like they belong to the wrong network
+    const isTestnetUrl =
+      horizonUrl.includes('testnet') || sorobanRpcUrl.includes('testnet');
+    const isMainnetUrl =
+      horizonUrl.includes('public') ||
+      horizonUrl.includes('mainnet') ||
+      sorobanRpcUrl.includes('public') ||
+      sorobanRpcUrl.includes('mainnet');
+
+    if (this.network === 'mainnet' && isTestnetUrl) {
+      this.logger.warn(
+        `⚠️  STELLAR_NETWORK is "mainnet" but Horizon/RPC URLs appear to point to testnet. ` +
+          `Horizon: ${horizonUrl}, Soroban: ${sorobanRpcUrl}`,
+      );
+    }
+    if (this.network === 'testnet' && isMainnetUrl) {
+      this.logger.warn(
+        `⚠️  STELLAR_NETWORK is "testnet" but Horizon/RPC URLs appear to point to mainnet. ` +
+          `Horizon: ${horizonUrl}, Soroban: ${sorobanRpcUrl}`,
+      );
+    }
+
     this.server = new StellarSdk.Horizon.Server(horizonUrl);
     this.sorobanServer = new SorobanRpc.Server(sorobanRpcUrl);
-
     this.logger.log(`Initialized Stellar service for ${this.network}`);
   }
 
   /**
    * Fetches the current ledger sequence number from Horizon.
-   * Used to convert wall-clock expiry times to ledger-based expiry
-   * required by EphemeralAccount.initialize() on-chain.
+   * Uses a short-lived in-memory cache to avoid redundant Horizon calls (#218).
    *
    * Stellar closes a ledger approximately every 5 seconds.
    * Conversion: expiry_ledger = current_ledger + Math.ceil(expiresInSeconds / 5)
    */
   async getCurrentLedger(): Promise<number> {
+    const now = Date.now();
+    if (
+      this.cachedLedger !== null &&
+      now - this.cachedLedgerAt < StellarService.LEDGER_CACHE_TTL_MS
+    ) {
+      this.logger.debug(
+        `Current ledger sequence (cached): ${this.cachedLedger}`,
+      );
+      return this.cachedLedger;
+    }
+
     const ledgerPage = await this.server
       .ledgers()
       .order('desc')
@@ -47,6 +103,8 @@ export class StellarService {
       .call();
 
     const sequence = ledgerPage.records[0].sequence;
+    this.cachedLedger = sequence;
+    this.cachedLedgerAt = now;
     this.logger.debug(`Current ledger sequence: ${sequence}`);
     return sequence;
   }
@@ -315,11 +373,7 @@ export class StellarService {
         `execute_sweep failed for ${params.ephemeralAccountContractId}: ${errStr}`,
       );
 
-      // Surface terminal errors explicitly so callers don't retry
-      if (errStr.includes('AlreadySwept')) throw new Error('ALREADY_SWEPT');
-      if (errStr.includes('AccountExpired')) throw new Error('ACCOUNT_EXPIRED');
-
-      throw new Error(`execute_sweep failed: ${errStr}`);
+      throwContractError(errStr);
     }
 
     await this.waitForTransaction(result.hash);
@@ -386,10 +440,7 @@ export class StellarService {
 
     if (result.status === 'ERROR') {
       const errStr = JSON.stringify(result.errorResult);
-      if (errStr.includes('InvalidStatus')) {
-        throw new Error('ACCOUNT_ALREADY_TERMINAL');
-      }
-      throw new Error(`expire() failed: ${errStr}`);
+      throwContractError(errStr);
     }
 
     await this.waitForTransaction(result.hash);


### PR DESCRIPTION
## Summary
Implements four improvements to the bridgelet-sdk backend for reliability, security, and operational readiness.

## Changes
- **#213**: Pin `@stellar/stellar-sdk` to exact version (14.4.3) and add `engines` field for reproducible installs
- **#218**: Add 10s in-memory cache for `getCurrentLedger()` to reduce redundant Horizon RPC calls
- **#212**: Add Horizon URL / network mismatch validation on module init with startup warning
- **#215**: Replace inline error string matching with `throwContractError()` in `executeSweep()` and `expireAccount()`

closes #212, closes #213, closes #215, closes #218