### PR TITLE
docs: add runbooks for account lifecycle diagnostics (Closes #300-#303)

### DIFF
--- a/bridgelet-sdk-audit/runbooks/diagnose-failed-account-creation.md
+++ b/bridgelet-sdk-audit/runbooks/diagnose-failed-account-creation.md
@@ -22,11 +22,11 @@ FROM accounts
 WHERE "publicKey" = '{publicKey}' OR id = '{accountId}';
 ```
 
-| Status | Meaning |
-|---|---|
-| `INITIALIZING` | DB record created, but neither Horizon nor Soroban completed. Timeout job will mark it `FAILED`. |
+| Status            | Meaning                                                                                                   |
+| ----------------- | --------------------------------------------------------------------------------------------------------- |
+| `INITIALIZING`    | DB record created, but neither Horizon nor Soroban completed. Timeout job will mark it `FAILED`.          |
 | `PENDING_PAYMENT` | Horizon `CreateAccount` succeeded **and** Soroban `initialize()` succeeded. Account is fully operational. |
-| `FAILED` | One of the two steps failed. Check `metadata.failureReason`. |
+| `FAILED`          | One of the two steps failed. Check `metadata.failureReason`.                                              |
 
 ## Step 2 — Check if the Stellar Account Exists
 
@@ -82,6 +82,7 @@ Accounts stuck here beyond the timeout indicate the cleanup scheduler is also no
 If the Horizon account was created (Step 2 returns 200) but the contract was never initialized (Step 4), you have an **unrestricted funded account** on-chain. This is the non-atomicity issue documented as internal Issue #15.
 
 **Remediation options:**
+
 1. **Wait for expiry**: If `expiresAt` is set, the expiry scheduler will eventually call `expire()`. However, `expire()` requires the contract to be initialized, which it is not in this case.
 2. **Account merge**: Manually merge the account's 2 XLM back to the funding keypair using the ephemeral secret key (if it can be decrypted from `secretKeyEncrypted`). This is a manual intervention.
 3. **Mark as FAILED**: Update the DB status and log the orphaned account for manual on-chain cleanup.
@@ -90,10 +91,10 @@ If the Horizon account was created (Step 2 returns 200) but the contract was nev
 
 ## Resolution Summary
 
-| Root cause | Resolution |
-|---|---|
-| Horizon CreateAccount failed (no on-chain account) | Check funding keypair balance, retry creation |
-| Horizon succeeded, Soroban initialize() failed | Retry initialization or mark FAILED and fund manually |
-| Funding keypair insufficient balance | Top up the funding keypair |
-| INITIALIZING cleanup job not running | Restart scheduler service, accounts will be auto-marked FAILED |
-| Non-atomic orphaned account (Issue #15) | Manual intervention: merge account back to funding keypair |
+| Root cause                                         | Resolution                                                     |
+| -------------------------------------------------- | -------------------------------------------------------------- |
+| Horizon CreateAccount failed (no on-chain account) | Check funding keypair balance, retry creation                  |
+| Horizon succeeded, Soroban initialize() failed     | Retry initialization or mark FAILED and fund manually          |
+| Funding keypair insufficient balance               | Top up the funding keypair                                     |
+| INITIALIZING cleanup job not running               | Restart scheduler service, accounts will be auto-marked FAILED |
+| Non-atomic orphaned account (Issue #15)            | Manual intervention: merge account back to funding keypair     |

--- a/bridgelet-sdk-audit/runbooks/diagnose-failed-account-creation.md
+++ b/bridgelet-sdk-audit/runbooks/diagnose-failed-account-creation.md
@@ -1,0 +1,99 @@
+# Runbook: Diagnosing a Failed createEphemeralAccount() Call
+
+> **Scope:** SDK-side triage only. This runbook covers the Horizon + Soroban two-phase creation flow and how to determine which phase failed.
+
+## Symptom
+
+An account creation request returned an error, or the account is stuck in `INITIALIZING` status past the timeout window.
+
+## Prerequisites
+
+- Database access to the `accounts` table
+- Stellar account public key of the ephemeral account
+- Access to SDK application logs
+
+---
+
+## Step 1 — Check Account Status in the Database
+
+```sql
+SELECT id, "publicKey", status, "contractId", "expiresAt", "createdAt", metadata
+FROM accounts
+WHERE "publicKey" = '{publicKey}' OR id = '{accountId}';
+```
+
+| Status | Meaning |
+|---|---|
+| `INITIALIZING` | DB record created, but neither Horizon nor Soroban completed. Timeout job will mark it `FAILED`. |
+| `PENDING_PAYMENT` | Horizon `CreateAccount` succeeded **and** Soroban `initialize()` succeeded. Account is fully operational. |
+| `FAILED` | One of the two steps failed. Check `metadata.failureReason`. |
+
+## Step 2 — Check if the Stellar Account Exists
+
+```
+GET https://horizon.stellar.org/accounts/{publicKey}
+```
+
+- **404 — Account not found**: The Horizon `CreateAccount` operation failed or was never submitted. The failure is at the Horizon stage. Proceed to Step 3.
+- **200 — Account found**: The Horizon `CreateAccount` succeeded. Check `balances` for 2 XLM (base reserve). If found, proceed to Step 4.
+
+## Step 3 — Horizon-Stage Failure
+
+If the account does not exist on-chain:
+
+1. Check SDK logs for `CreateAccount` errors around the creation timestamp.
+2. Common Horizon failures:
+   - `tx_insufficient_balance`: The **funding keypair** (`stellar.fundingSecret`) has insufficient XLM to fund the 2 XLM base reserve.
+   - `tx_bad_auth`: The funding keypair could not sign the transaction.
+   - `tx_too_late`: The transaction expired before Horizon processed it.
+3. Check the funding keypair's balance:
+   ```
+   GET https://horizon.stellar.org/accounts/{fundingPublicKey}
+   ```
+   Ensure it holds more than 2 XLM (plus fees for subsequent operations).
+
+## Step 4 — Soroban-Stage Failure (Account Exists but Uninitialized)
+
+If the account exists on Horizon with 2 XLM but is in `INITIALIZING` status:
+
+1. The Horizon `CreateAccount` succeeded, but the Soroban `EphemeralAccount.initialize()` call failed.
+2. Check SDK logs for the specific contract error:
+   - `AlreadyInitialized`: The contract was somehow already initialized (rare, indicates a retry).
+   - `InvalidExpiry`: The calculated expiry ledger is in the past or invalid.
+   - Network/RPC errors: Soroban RPC was unreachable or timed out.
+3. Check the on-chain contract state directly (if the contract address is known):
+   - This requires the contract's C... address, which is stored in `accounts.contractId`. If `contractId` is NULL, the Soroban call never completed.
+
+## Step 5 — Check the INITIALIZING Cleanup Job
+
+The SDK has a scheduler that marks `INITIALIZING` accounts as `FAILED` after a timeout (default: `INITIALIZING_TIMEOUT_MS = 10 minutes`, runs every 15 minutes).
+
+```sql
+SELECT id, "publicKey", metadata
+FROM accounts
+WHERE status = 'initializing'
+AND "createdAt" < now() - interval '10 minutes';
+```
+
+Accounts stuck here beyond the timeout indicate the cleanup scheduler is also not running. Check scheduler service health.
+
+## Step 6 — Unfunded, Uninitialized Account Cleanup
+
+If the Horizon account was created (Step 2 returns 200) but the contract was never initialized (Step 4), you have an **unrestricted funded account** on-chain. This is the non-atomicity issue documented as internal Issue #15.
+
+**Remediation options:**
+1. **Wait for expiry**: If `expiresAt` is set, the expiry scheduler will eventually call `expire()`. However, `expire()` requires the contract to be initialized, which it is not in this case.
+2. **Account merge**: Manually merge the account's 2 XLM back to the funding keypair using the ephemeral secret key (if it can be decrypted from `secretKeyEncrypted`). This is a manual intervention.
+3. **Mark as FAILED**: Update the DB status and log the orphaned account for manual on-chain cleanup.
+
+---
+
+## Resolution Summary
+
+| Root cause | Resolution |
+|---|---|
+| Horizon CreateAccount failed (no on-chain account) | Check funding keypair balance, retry creation |
+| Horizon succeeded, Soroban initialize() failed | Retry initialization or mark FAILED and fund manually |
+| Funding keypair insufficient balance | Top up the funding keypair |
+| INITIALIZING cleanup job not running | Restart scheduler service, accounts will be auto-marked FAILED |
+| Non-atomic orphaned account (Issue #15) | Manual intervention: merge account back to funding keypair |

--- a/bridgelet-sdk-audit/runbooks/diagnose-failed-sweep-from-sdk-side.md
+++ b/bridgelet-sdk-audit/runbooks/diagnose-failed-sweep-from-sdk-side.md
@@ -30,39 +30,41 @@ Look for the raw `errorResult` JSON before any string matching is applied. The e
 
 The SDK's `contract-error.mapper.ts` maps raw Soroban contract error strings to structured HTTP errors. Cross-reference the raw error string against these known variants:
 
-| Contract Error | HTTP Status | Error Code | Retriable? | Meaning |
-|---|---|---|---|---|
-| `AlreadySwept` | 410 | `ALREADY_SWEPT` | No | Contract already in Swept state |
-| `AccountExpired` | 410 | `ACCOUNT_EXPIRED` | No | Account's expiry_ledger has passed on-chain |
-| `NoPaymentReceived` | 400 | `NO_PAYMENT_RECEIVED` | No | record_payment was never called |
-| `InvalidStatus` | 409 | `INVALID_STATUS` | No | Contract not in a sweepable state |
-| `AuthorizationFailed` | 403 | `AUTHORIZATION_FAILED` | No | Auth signature verification failed |
-| `UnauthorizedDestination` | 403 | `UNAUTHORIZED_DESTINATION` | No | Destination not authorized |
-| `AccountAlreadySwept` | 410 | `ACCOUNT_ALREADY_SWEPT` | No | Variant of AlreadySwept |
-| Unknown string | 500 | `UNKNOWN_CONTRACT_ERROR` | No | Catch-all |
+| Contract Error            | HTTP Status | Error Code                 | Retriable? | Meaning                                     |
+| ------------------------- | ----------- | -------------------------- | ---------- | ------------------------------------------- |
+| `AlreadySwept`            | 410         | `ALREADY_SWEPT`            | No         | Contract already in Swept state             |
+| `AccountExpired`          | 410         | `ACCOUNT_EXPIRED`          | No         | Account's expiry_ledger has passed on-chain |
+| `NoPaymentReceived`       | 400         | `NO_PAYMENT_RECEIVED`      | No         | record_payment was never called             |
+| `InvalidStatus`           | 409         | `INVALID_STATUS`           | No         | Contract not in a sweepable state           |
+| `AuthorizationFailed`     | 403         | `AUTHORIZATION_FAILED`     | No         | Auth signature verification failed          |
+| `UnauthorizedDestination` | 403         | `UNAUTHORIZED_DESTINATION` | No         | Destination not authorized                  |
+| `AccountAlreadySwept`     | 410         | `ACCOUNT_ALREADY_SWEPT`    | No         | Variant of AlreadySwept                     |
+| Unknown string            | 500         | `UNKNOWN_CONTRACT_ERROR`   | No         | Catch-all                                   |
 
 **Important caveat (see execute-sweep-error-mapping-completeness.md):** A bad Ed25519 signature may cause a raw Wasm trap on the contract side rather than returning a typed `AuthorizationFailed` error. If you see a generic `Error` or trap message rather than one of the known variants above, the signature verification may have panicked rather than returned an error. This gap is documented in the integration notes.
 
 ## Step 3 — Distinguish Contract vs Horizon Errors
 
 The SDK executes sweeps in two phases:
+
 1. **Soroban contract call** (`execute_sweep()`) — can fail with any of the above contract errors.
 2. **Horizon payment** (classic `Operation.payment()`) — can fail with Horizon-specific errors.
 
 Horizon errors are mapped by `horizon-error.mapper.ts`:
 
-| Horizon Code | HTTP Status | Meaning |
-|---|---|---|
-| `tx_bad_auth` | 401 | Ephemeral account secret key invalid |
-| `tx_insufficient_balance` | 402 | Not enough XLM for the payment |
-| `tx_too_late` | 408 | Transaction expired before confirmation |
-| `tx_bad_seq` | 409 | Sequence number conflict |
+| Horizon Code              | HTTP Status | Meaning                                 |
+| ------------------------- | ----------- | --------------------------------------- |
+| `tx_bad_auth`             | 401         | Ephemeral account secret key invalid    |
+| `tx_insufficient_balance` | 402         | Not enough XLM for the payment          |
+| `tx_too_late`             | 408         | Transaction expired before confirmation |
+| `tx_bad_seq`              | 409         | Sequence number conflict                |
 
 If the contract call succeeded but the Horizon payment failed, the account enters `PARTIAL_SWEEP` status. This is a specific, recoverable state.
 
 ## Step 4 — PARTIAL_SWEEP Recovery
 
 When an account is in `PARTIAL_SWEEP`:
+
 - The on-chain contract is already in `Swept` state (the contract call succeeded).
 - The Horizon payment to the destination failed.
 - On retry, the SDK sets `skipContractAuth: true`, which skips the contract call and goes directly to the Horizon payment.
@@ -73,6 +75,7 @@ Check whether the `sweep.partial` webhook was delivered to the integrator. If no
 ## Step 5 — Cross-Reference with bridgelet-audit
 
 For the on-chain side of the diagnosis (contract state, transaction traces, authorization verification), refer to:
+
 - `bridgelet-audit/diagnose-failed-sweep.md` — on-chain diagnostic steps
 - `bridgelet-audit/ed25519-verify-panic-vs-result.md` — signature verification behavior
 - `execute-sweep-error-mapping-completeness.md` in this repo — SDK-side mapping gaps
@@ -87,13 +90,13 @@ If the service was restarted during a retry cycle, the queue is lost. Check logs
 
 ## Resolution Summary
 
-| Root cause | Resolution |
-|---|---|
-| `ALREADY_SWEPT` / `ACCOUNT_ALREADY_SWEPT` | No action needed; sweep completed previously |
-| `ACCOUNT_EXPIRED` | Account expired on-chain; check if funds returned to recovery |
-| `NO_PAYMENT_RECEIVED` | Payment was never recorded; check payment monitor |
-| `AUTHORIZATION_FAILED` | Check sweep signing key matches the authorized_signer on-chain |
-| Bad signature causing Wasm trap | Known gap — see execute-sweep-error-mapping-completeness.md |
-| Horizon payment failed (PARTIAL_SWEEP) | Retry via claim endpoint; SDK skips contract auth on retry |
-| Horizon `tx_bad_auth` | Ephemeral secret key decryption failed or key is wrong |
-| Horizon `tx_insufficient_balance` | Account may have been partially drained; check balance |
+| Root cause                                | Resolution                                                     |
+| ----------------------------------------- | -------------------------------------------------------------- |
+| `ALREADY_SWEPT` / `ACCOUNT_ALREADY_SWEPT` | No action needed; sweep completed previously                   |
+| `ACCOUNT_EXPIRED`                         | Account expired on-chain; check if funds returned to recovery  |
+| `NO_PAYMENT_RECEIVED`                     | Payment was never recorded; check payment monitor              |
+| `AUTHORIZATION_FAILED`                    | Check sweep signing key matches the authorized_signer on-chain |
+| Bad signature causing Wasm trap           | Known gap — see execute-sweep-error-mapping-completeness.md    |
+| Horizon payment failed (PARTIAL_SWEEP)    | Retry via claim endpoint; SDK skips contract auth on retry     |
+| Horizon `tx_bad_auth`                     | Ephemeral secret key decryption failed or key is wrong         |
+| Horizon `tx_insufficient_balance`         | Account may have been partially drained; check balance         |

--- a/bridgelet-sdk-audit/runbooks/diagnose-failed-sweep-from-sdk-side.md
+++ b/bridgelet-sdk-audit/runbooks/diagnose-failed-sweep-from-sdk-side.md
@@ -1,0 +1,99 @@
+# Runbook: Diagnosing a Failed executeSweep() Call from the SDK's Perspective
+
+> **Scope:** SDK-side error interpretation only. For on-chain contract diagnostics, see bridgelet-audit's `diagnose-failed-sweep.md`.
+
+## Symptom
+
+A sweep request (from claim redemption or manual trigger) returned an error. The account may be in `PENDING_CLAIM`, `CLAIMING`, or `PARTIAL_SWEEP` status.
+
+## Prerequisites
+
+- Database access to the `accounts` and `claims` tables
+- SDK application logs
+- Access to the raw error response (not just the stringified message)
+
+---
+
+## Step 1 — Capture the Raw Error
+
+**Always start here.** The SDK's `executeSweep()` method catches errors in a try/catch and returns a `SweepResult` with an `error` field. However, some error paths use string-matching (`errStr.includes(...)`) which can miss cases.
+
+Check the SDK logs for the full error object:
+
+```
+grep "executeSweep" /var/log/bridgelet/sweeps*.log | grep "{accountId}"
+```
+
+Look for the raw `errorResult` JSON before any string matching is applied. The error string may be truncated or lose context in the catch-all path.
+
+## Step 2 — Map the Error to the Contract Error Table
+
+The SDK's `contract-error.mapper.ts` maps raw Soroban contract error strings to structured HTTP errors. Cross-reference the raw error string against these known variants:
+
+| Contract Error | HTTP Status | Error Code | Retriable? | Meaning |
+|---|---|---|---|---|
+| `AlreadySwept` | 410 | `ALREADY_SWEPT` | No | Contract already in Swept state |
+| `AccountExpired` | 410 | `ACCOUNT_EXPIRED` | No | Account's expiry_ledger has passed on-chain |
+| `NoPaymentReceived` | 400 | `NO_PAYMENT_RECEIVED` | No | record_payment was never called |
+| `InvalidStatus` | 409 | `INVALID_STATUS` | No | Contract not in a sweepable state |
+| `AuthorizationFailed` | 403 | `AUTHORIZATION_FAILED` | No | Auth signature verification failed |
+| `UnauthorizedDestination` | 403 | `UNAUTHORIZED_DESTINATION` | No | Destination not authorized |
+| `AccountAlreadySwept` | 410 | `ACCOUNT_ALREADY_SWEPT` | No | Variant of AlreadySwept |
+| Unknown string | 500 | `UNKNOWN_CONTRACT_ERROR` | No | Catch-all |
+
+**Important caveat (see execute-sweep-error-mapping-completeness.md):** A bad Ed25519 signature may cause a raw Wasm trap on the contract side rather than returning a typed `AuthorizationFailed` error. If you see a generic `Error` or trap message rather than one of the known variants above, the signature verification may have panicked rather than returned an error. This gap is documented in the integration notes.
+
+## Step 3 — Distinguish Contract vs Horizon Errors
+
+The SDK executes sweeps in two phases:
+1. **Soroban contract call** (`execute_sweep()`) — can fail with any of the above contract errors.
+2. **Horizon payment** (classic `Operation.payment()`) — can fail with Horizon-specific errors.
+
+Horizon errors are mapped by `horizon-error.mapper.ts`:
+
+| Horizon Code | HTTP Status | Meaning |
+|---|---|---|
+| `tx_bad_auth` | 401 | Ephemeral account secret key invalid |
+| `tx_insufficient_balance` | 402 | Not enough XLM for the payment |
+| `tx_too_late` | 408 | Transaction expired before confirmation |
+| `tx_bad_seq` | 409 | Sequence number conflict |
+
+If the contract call succeeded but the Horizon payment failed, the account enters `PARTIAL_SWEEP` status. This is a specific, recoverable state.
+
+## Step 4 — PARTIAL_SWEEP Recovery
+
+When an account is in `PARTIAL_SWEEP`:
+- The on-chain contract is already in `Swept` state (the contract call succeeded).
+- The Horizon payment to the destination failed.
+- On retry, the SDK sets `skipContractAuth: true`, which skips the contract call and goes directly to the Horizon payment.
+- A deterministic `contractAuthHash` is synthesized for the audit trail.
+
+Check whether the `sweep.partial` webhook was delivered to the integrator. If not, they may need to call the claim endpoint again to trigger the retry.
+
+## Step 5 — Cross-Reference with bridgelet-audit
+
+For the on-chain side of the diagnosis (contract state, transaction traces, authorization verification), refer to:
+- `bridgelet-audit/diagnose-failed-sweep.md` — on-chain diagnostic steps
+- `bridgelet-audit/ed25519-verify-panic-vs-result.md` — signature verification behavior
+- `execute-sweep-error-mapping-completeness.md` in this repo — SDK-side mapping gaps
+
+## Step 6 — Check Retry Queue State
+
+The SDK has an in-memory retry queue (`SweepRetryQueueService`) with exponential backoff (base 2s, max 5min, default 5 attempts). Terminal errors (`ALREADY_SWEPT`, `ACCOUNT_EXPIRED`) are not retried.
+
+If the service was restarted during a retry cycle, the queue is lost. Check logs for the most recent retry attempt. If no retry logs exist after a restart, the sweep may need to be manually retriggered.
+
+---
+
+## Resolution Summary
+
+| Root cause | Resolution |
+|---|---|
+| `ALREADY_SWEPT` / `ACCOUNT_ALREADY_SWEPT` | No action needed; sweep completed previously |
+| `ACCOUNT_EXPIRED` | Account expired on-chain; check if funds returned to recovery |
+| `NO_PAYMENT_RECEIVED` | Payment was never recorded; check payment monitor |
+| `AUTHORIZATION_FAILED` | Check sweep signing key matches the authorized_signer on-chain |
+| Bad signature causing Wasm trap | Known gap — see execute-sweep-error-mapping-completeness.md |
+| Horizon payment failed (PARTIAL_SWEEP) | Retry via claim endpoint; SDK skips contract auth on retry |
+| Horizon `tx_bad_auth` | Ephemeral secret key decryption failed or key is wrong |
+| Horizon `tx_insufficient_balance` | Account may have been partially drained; check balance |

--- a/bridgelet-sdk-audit/runbooks/diagnose-stuck-pending-payment-account.md
+++ b/bridgelet-sdk-audit/runbooks/diagnose-stuck-pending-payment-account.md
@@ -54,12 +54,12 @@ grep "{publicKey}" /var/log/bridgelet/payment-monitor*.log
 
 Look for these patterns:
 
-| Log message | Meaning |
-|---|---|
-| `DuplicateAsset` | On-chain `record_payment()` was called but the asset was already recorded. This is benign and indicates the payment-monitor detected the payment but the on-chain call succeeded for a *different* asset first. |
-| `TooManyPayments` | The on-chain contract hit its 10-asset limit. The account is likely terminal — check status. |
-| `InvalidAmount` | The payment amount could not be parsed to i128 stroops. The account is terminal. |
-| `PENDING_PAYMENT → PENDING_CLAIM` | The transition succeeded — the account should no longer be `PENDING_PAYMENT`. If it still is, the DB write may have failed. |
+| Log message                       | Meaning                                                                                                                                                                                                         |
+| --------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `DuplicateAsset`                  | On-chain `record_payment()` was called but the asset was already recorded. This is benign and indicates the payment-monitor detected the payment but the on-chain call succeeded for a _different_ asset first. |
+| `TooManyPayments`                 | The on-chain contract hit its 10-asset limit. The account is likely terminal — check status.                                                                                                                    |
+| `InvalidAmount`                   | The payment amount could not be parsed to i128 stroops. The account is terminal.                                                                                                                                |
+| `PENDING_PAYMENT → PENDING_CLAIM` | The transition succeeded — the account should no longer be `PENDING_PAYMENT`. If it still is, the DB write may have failed.                                                                                     |
 
 ## Step 4 — Single-Asset Limitation (Cross-Reference)
 
@@ -93,11 +93,11 @@ If the account is close to expiry, the expiry scheduler may run before the payme
 
 ## Resolution Summary
 
-| Root cause | Resolution |
-|---|---|
-| No payment sent | Ask integrator to resend |
-| Payment sent but wrong asset | Note single-asset limitation; second payment is invisible |
-| Payment monitor down / stalled | Restart the monitor service |
-| DuplicateAsset warnings only | On-chain is fine; check DB connection for the status transition |
+| Root cause                      | Resolution                                                      |
+| ------------------------------- | --------------------------------------------------------------- |
+| No payment sent                 | Ask integrator to resend                                        |
+| Payment sent but wrong asset    | Note single-asset limitation; second payment is invisible       |
+| Payment monitor down / stalled  | Restart the monitor service                                     |
+| DuplicateAsset warnings only    | On-chain is fine; check DB connection for the status transition |
 | InvalidAmount / TooManyPayments | Terminal — status should be `FAILED` or `PENDING_CLAIM` already |
-| Account near expiry | May expire before claim; coordinate with integrator on timing |
+| Account near expiry             | May expire before claim; coordinate with integrator on timing   |

--- a/bridgelet-sdk-audit/runbooks/diagnose-stuck-pending-payment-account.md
+++ b/bridgelet-sdk-audit/runbooks/diagnose-stuck-pending-payment-account.md
@@ -1,0 +1,103 @@
+# Runbook: Diagnosing an Account Stuck in PENDING_PAYMENT
+
+> **Scope:** SDK-side triage only. For on-chain contract diagnostics, see bridgelet-audit's `diagnose-failed-sweep.md`.
+
+## Symptom
+
+An account remains in `PENDING_PAYMENT` status long after creation. The expected inbound Stellar payment either never arrived or was not detected by the SDK.
+
+## Prerequisites
+
+- Database access to the `accounts` table
+- Stellar account public key of the ephemeral account
+- Access to SDK application logs (Pino / CloudWatch)
+
+---
+
+## Step 1 — Verify the Account Exists On-Chain
+
+```sql
+SELECT id, "publicKey", status, "expiresAt", "createdAt"
+FROM accounts
+WHERE status = 'pending_payment';
+```
+
+Copy the `publicKey` and check it on Stellar Expert or Horizon:
+
+```
+GET https://horizon.stellar.org/accounts/{publicKey}
+```
+
+- If **404**: the Horizon `CreateAccount` operation never landed. See `diagnose-failed-account-creation.md`.
+- If **200**: the account exists and is funded. Proceed to Step 2.
+
+## Step 2 — Check Horizon for Inbound Payments
+
+Query the account's payment history on Horizon:
+
+```
+GET https://horizon.stellar.org/accounts/{publicKey}/payments?order=desc&limit=20
+```
+
+Look for any payment whose `to` matches the ephemeral `publicKey`.
+
+- **No payments found**: The funding integrator or user never sent funds to this account. Confirm the amount and asset with the caller. This is the most common root cause.
+- **Payments found**: A payment arrived. Proceed to Step 3.
+
+## Step 3 — Check the Payment-Monitor Logs
+
+Search SDK logs for the account's public key around the time the payment arrived:
+
+```
+grep "{publicKey}" /var/log/bridgelet/payment-monitor*.log
+```
+
+Look for these patterns:
+
+| Log message | Meaning |
+|---|---|
+| `DuplicateAsset` | On-chain `record_payment()` was called but the asset was already recorded. This is benign and indicates the payment-monitor detected the payment but the on-chain call succeeded for a *different* asset first. |
+| `TooManyPayments` | The on-chain contract hit its 10-asset limit. The account is likely terminal — check status. |
+| `InvalidAmount` | The payment amount could not be parsed to i128 stroops. The account is terminal. |
+| `PENDING_PAYMENT → PENDING_CLAIM` | The transition succeeded — the account should no longer be `PENDING_PAYMENT`. If it still is, the DB write may have failed. |
+
+## Step 4 — Single-Asset Limitation (Cross-Reference)
+
+If a payment arrived on-chain but was not the **first** payment detected by the SDK's payment monitor, it will be silently ignored. The SDK's `PaymentMonitorService` transitions the account to `PENDING_CLAIM` after the first detected payment and stops polling for that account entirely.
+
+The on-chain contract (`record_payment`) supports up to 10 distinct assets, but the SDK only processes one. Any subsequent asset sent to this account will never be recorded in the database or reflected in the claim flow.
+
+**Detection:** Compare the first payment's asset against what the integrator expected. If the integrator sent a different asset second, it will be invisible to the SDK.
+
+See `integration-notes/payment-monitor-single-asset-limitation.md` for full details.
+
+## Step 5 — Check Payment-Monitor Service Health
+
+If the payment monitor is not running or is behind schedule:
+
+1. Check the process is alive: `ps aux | grep payment-monitor` (or the NestJS scheduler logs).
+2. Check the polling interval: default is 30 seconds (`PAYMENT_MONITOR_INTERVAL_MS`).
+3. If using the SSE-based `PaymentMonitorProvider`, check for stream disconnection logs.
+
+A stalled payment monitor will cause all `PENDING_PAYMENT` accounts to appear stuck.
+
+## Step 6 — Check Account Expiry
+
+```sql
+SELECT "expiresAt" FROM accounts WHERE "publicKey" = '{publicKey}';
+```
+
+If the account is close to expiry, the expiry scheduler may run before the payment is detected. In that case, the account will transition to `EXPIRED` rather than `PENDING_CLAIM`.
+
+---
+
+## Resolution Summary
+
+| Root cause | Resolution |
+|---|---|
+| No payment sent | Ask integrator to resend |
+| Payment sent but wrong asset | Note single-asset limitation; second payment is invisible |
+| Payment monitor down / stalled | Restart the monitor service |
+| DuplicateAsset warnings only | On-chain is fine; check DB connection for the status transition |
+| InvalidAmount / TooManyPayments | Terminal — status should be `FAILED` or `PENDING_CLAIM` already |
+| Account near expiry | May expire before claim; coordinate with integrator on timing |

--- a/bridgelet-sdk-audit/runbooks/rotate-funding-keypair.md
+++ b/bridgelet-sdk-audit/runbooks/rotate-funding-keypair.md
@@ -37,6 +37,7 @@ Update `FUNDING_ACCOUNT_SECRET` (or `stellar.fundingSecret` in the NestJS config
 ### 2. Restart the SDK Service
 
 Perform a **graceful restart** (SIGTERM → SIGKILL after drain timeout) to ensure:
+
 - In-flight account creation requests complete before shutdown.
 - The payment monitor SSE streams are re-established.
 - The new funding keypair is loaded into `StellarService`.
@@ -67,6 +68,7 @@ curl -X POST https://{api-host}/accounts \
 ```
 
 Verify:
+
 - The Horizon `CreateAccount` transaction was signed by the **new** public key.
 - The account status transitions to `PENDING_PAYMENT`.
 

--- a/bridgelet-sdk-audit/runbooks/rotate-funding-keypair.md
+++ b/bridgelet-sdk-audit/runbooks/rotate-funding-keypair.md
@@ -1,0 +1,98 @@
+# Runbook: Rotating the Stellar Funding Keypair
+
+> **Scope:** Operational steps for rotating the `stellar.fundingSecret` environment variable used by the SDK.
+
+## Background
+
+The Stellar funding keypair (`FUNDING_ACCOUNT_SECRET`) is used in two critical SDK paths:
+
+1. **Account creation** (`createEphemeralAccount()`): Signs the Horizon `CreateAccount` operation (funds the new ephemeral account with 2 XLM) and the Soroban `initialize()` contract call.
+2. **Payment recording / expiry** (`recordPayment()`, `expireAccount()`): Signs the Soroban `record_payment()` and `expire()` contract calls on the ephemeral account's contract.
+
+The same keypair is used as `signerSecret` in `StellarService` for all contract-related transactions.
+
+---
+
+## Pre-Rotation Checklist
+
+- [ ] Confirm the **new** keypair has been generated and its secret is available.
+- [ ] Confirm the new keypair has been **funded** with sufficient XLM:
+  ```
+  GET https://horizon.stellar.org/accounts/{newPublicKey}
+  ```
+  Minimum recommended balance: **100 XLM** (each account creation costs 2 XLM + fees; each sweep costs fees).
+- [ ] Confirm the new public key matches the `authorized_signer` registered in the `SweepController` Soroban contract (if the contract enforces it). **If the contract's `authorized_signer` does not match the new public key, sweeps will fail with `AuthorizationFailed`.**
+- [ ] Schedule a **maintenance window** during low traffic.
+
+## Rotation Steps
+
+### 1. Update the Environment Variable
+
+Update `FUNDING_ACCOUNT_SECRET` (or `stellar.fundingSecret` in the NestJS config) with the new keypair's **secret seed** (starts with `S...`).
+
+- For AWS: update the Secrets Manager entry or SSM Parameter Store value.
+- For Docker/K8s: update the secret and trigger a rolling restart.
+- For bare metal: update the `.env` file and restart the service.
+
+### 2. Restart the SDK Service
+
+Perform a **graceful restart** (SIGTERM → SIGKILL after drain timeout) to ensure:
+- In-flight account creation requests complete before shutdown.
+- The payment monitor SSE streams are re-established.
+- The new funding keypair is loaded into `StellarService`.
+
+### 3. Verify Funding Keypair Balance
+
+After restart, confirm the service is using the new keypair:
+
+```
+grep "fundingKeypair" /var/log/bridgelet/stellar*.log | tail -5
+```
+
+Or query the Stellar network for transactions signed by the new public key after restart.
+
+### 4. Test Account Creation
+
+Create a test account via the API:
+
+```bash
+curl -X POST https://{api-host}/accounts \
+  -H "X-API-Key: {test-integrator-key}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "amount": "1.0000000",
+    "asset_code": "native",
+    "expiresIn": 3600
+  }'
+```
+
+Verify:
+- The Horizon `CreateAccount` transaction was signed by the **new** public key.
+- The account status transitions to `PENDING_PAYMENT`.
+
+### 5. Test Payment Recording (Optional)
+
+If possible, send a small payment to the test account and verify the payment monitor detects it and calls `record_payment()` successfully.
+
+### 6. Drain Old Keypair (Optional but Recommended)
+
+If the old keypair has remaining XLM balance, merge it back to a known treasury account:
+
+```
+stellar --network public account merge --source {oldSecret} --destination {treasuryPublicKey}
+```
+
+Or send all remaining funds via a payment operation.
+
+## Downtime and Coordination
+
+- **Minimal downtime expected**: The rotation is a configuration change followed by a restart. The service should be back within 30–60 seconds.
+- **In-flight requests**: Account creation requests that started before the restart will use the **old** keypair. These will still succeed because the old keypair remains valid on Stellar until explicitly removed from the network. No special handling is needed.
+- **Pending payments**: Accounts in `PENDING_PAYMENT` status that have not yet had their payment recorded will continue to use the old keypair for `record_payment()` calls. These calls succeed because the old keypair is still the account's signer. After rotation, the payment monitor picks up these accounts and uses the new keypair for subsequent Soroban calls **only if the contract authorization has been updated**.
+
+## Post-Rotation Monitoring
+
+- [ ] Monitor sweep success rate for 24 hours after rotation.
+- [ ] Check for `AuthorizationFailed` errors in sweep logs (indicates contract `authorized_signer` mismatch).
+- [ ] Verify new accounts created after rotation use the new keypair.
+- [ ] Confirm old keypair has no remaining balance after drain.


### PR DESCRIPTION
This PR adds four operational runbooks to bridgelet-sdk-audit/runbooks/:

1. **diagnose-stuck-pending-payment-account.md** (#300): Step-by-step guide for triaging accounts stuck in `PENDING_PAYMENT` status — from Horizon account verification through payment monitor logs to the single-asset limitation.

2. **diagnose-failed-account-creation.md** (#301): Documents the two-phase creation flow (Horizon CreateAccount → Soroban initialize()) and how to determine which phase failed, including the non-atomicity gap (Issue #15) for orphaned funded accounts.

3. **diagnose-failed-sweep-from-sdk-side.md** (#302): Maps SDK-side error responses to their root causes, including the Ed25519 Wasm trap caveat and PARTIAL_SWEEP recovery behavior.

4. **rotate-funding-keypair.md** (#303): Operational runbook for rotating the `FUNDING_ACCOUNT_SECRET`, including pre-rotation checks (authorized_signer alignment), downtime expectations, and post-rotation monitoring.

Closes #300, Closes #301, Closes #302, Closes #303