### PR TITLE
docs: add integration notes for SDK error handling (Closes #292-#295)

### DIFF
--- a/bridgelet-sdk-audit/integration-notes/ed25519-signature-verification.md
+++ b/bridgelet-sdk-audit/integration-notes/ed25519-signature-verification.md
@@ -18,10 +18,10 @@ There are two possible failure modes when a signature is invalid:
 
 If your integration ever sends an invalid Ed25519 signature during the sweep authorization step, the error you receive depends on the failure mode:
 
-| Failure Mode | SDK HTTP Response | SDK Error Code | Your SDK Can Catch? |
-|---|---|---|---|
-| Returned error | 403 | `AUTHORIZATION_FAILED` | Yes |
-| Wasm trap (panic) | 500 | `UNKNOWN_CONTRACT_ERROR` | No — indistinguishable from any other contract error |
+| Failure Mode      | SDK HTTP Response | SDK Error Code           | Your SDK Can Catch?                                  |
+| ----------------- | ----------------- | ------------------------ | ---------------------------------------------------- |
+| Returned error    | 403               | `AUTHORIZATION_FAILED`   | Yes                                                  |
+| Wasm trap (panic) | 500               | `UNKNOWN_CONTRACT_ERROR` | No — indistinguishable from any other contract error |
 
 **Recommendation**: If you see a 500 error with `UNKNOWN_CONTRACT_ERROR` during sweep authorization, check whether your Ed25519 signature or public key is correctly formatted before retrying. The SDK currently has no way to distinguish a signature-panic from other contract failures.
 

--- a/bridgelet-sdk-audit/integration-notes/ed25519-signature-verification.md
+++ b/bridgelet-sdk-audit/integration-notes/ed25519-signature-verification.md
@@ -1,0 +1,30 @@
+# Integration Note: Ed25519 Signature Verification — Panic vs Returned Error
+
+> **For integrators** using the bridgelet-sdk sweep/claim flow.
+
+## Context
+
+When an account is claimed and swept, the SDK executes a Soroban smart contract call (`execute_sweep`) that performs Ed25519 signature verification on-chain. The contract uses Stellar's `Ed25519Verify128` host function to verify the caller's authorization.
+
+## The Issue
+
+There are two possible failure modes when a signature is invalid:
+
+1. **Returned error**: The contract validates the signature, finds it invalid, and returns an `AuthorizationFailed` error in a structured way. The SDK can parse this and return a meaningful 403 HTTP response.
+
+2. **Wasm trap (panic)**: The Soroban runtime encounters a situation where the signature verification triggers an unrecoverable error (e.g., invalid key length, malformed signature bytes). Instead of returning a structured error, the contract execution **panics** with a raw trap. The SDK receives an unstructured `Error` type that does not match the known contract error string patterns.
+
+## Impact on Your Integration
+
+If your integration ever sends an invalid Ed25519 signature during the sweep authorization step, the error you receive depends on the failure mode:
+
+| Failure Mode | SDK HTTP Response | SDK Error Code | Your SDK Can Catch? |
+|---|---|---|---|
+| Returned error | 403 | `AUTHORIZATION_FAILED` | Yes |
+| Wasm trap (panic) | 500 | `UNKNOWN_CONTRACT_ERROR` | No — indistinguishable from any other contract error |
+
+**Recommendation**: If you see a 500 error with `UNKNOWN_CONTRACT_ERROR` during sweep authorization, check whether your Ed25519 signature or public key is correctly formatted before retrying. The SDK currently has no way to distinguish a signature-panic from other contract failures.
+
+## What We Are Doing
+
+We have documented this gap and are tracking it for a future fix. The contract should return a structured `AuthorizationFailed` error in all cases rather than allowing the Wasm runtime to trap. Until then, treat any 500 error during sweep authorization as a potential signature issue.

--- a/bridgelet-sdk-audit/integration-notes/partial-sweep-recovery.md
+++ b/bridgelet-sdk-audit/integration-notes/partial-sweep-recovery.md
@@ -1,0 +1,48 @@
+# Integration Note: Partial Sweep Recovery
+
+> **For integrators** using the bridgelet-sdk sweep/claim flow.
+
+## What Is a Partial Sweep?
+
+A partial sweep occurs when the Soroban contract call (`execute_sweep`) **succeeds** but the subsequent Horizon payment to the destination address **fails**. The SDK tracks this as `PARTIAL_SWEEP` status.
+
+```
+Contract call: ✓ Swept on-chain
+Horizon payment: ✗ Failed to send funds
+Result: Account is PARTIAL_SWEEP
+```
+
+This is a transient, recoverable state.
+
+## How Recovery Works
+
+When a sweep fails with `PARTIAL_SWEEP`:
+
+1. The SDK enqueues the account into an in-memory retry queue with exponential backoff.
+2. On retry, the SDK skips the Soroban contract call (`skipContractAuth: true`) since the contract is already in `Swept` state.
+3. It synthesizes a deterministic `contractAuthHash` for the audit trail without making a contract call.
+4. It then executes the Horizon payment directly to the destination address.
+
+The retry parameters are:
+- **Base delay**: 2 seconds
+- **Maximum delay**: 5 minutes
+- **Max attempts**: 5
+
+## What You Need to Know
+
+1. **Webhook**: You will receive an `sweep.partial` webhook when this happens. This webhook includes the account ID and the current retry state.
+
+2. **No action required on your side**: The SDK handles recovery automatically. You do not need to re-trigger the claim.
+
+3. **If the service restarts**: The retry queue is in-memory. If the SDK service restarts during the retry cycle, the queue is lost. In this case, the sweep may need to be manually re-triggered by calling the claim endpoint again.
+
+4. **Terminal failure**: If all 5 retries are exhausted, the account will be marked as `FAILED`. You will receive an `sweep.failed` webhook and should investigate the underlying Horizon error.
+
+## Error Codes You May See
+
+| Horizon Error | Meaning | Resolution |
+|---|---|---|
+| `tx_bad_auth` | Invalid ephemeral secret key | Check SDK key encryption and decryption |
+| `tx_insufficient_balance` | Account lacks XLM for payment | Verify account was properly funded |
+| `tx_too_late` | Transaction expired | Check network congestion; SDK will retry |
+| `tx_bad_seq` | Sequence number conflict | SDK will retry with fresh sequence |

--- a/bridgelet-sdk-audit/integration-notes/partial-sweep-recovery.md
+++ b/bridgelet-sdk-audit/integration-notes/partial-sweep-recovery.md
@@ -24,6 +24,7 @@ When a sweep fails with `PARTIAL_SWEEP`:
 4. It then executes the Horizon payment directly to the destination address.
 
 The retry parameters are:
+
 - **Base delay**: 2 seconds
 - **Maximum delay**: 5 minutes
 - **Max attempts**: 5
@@ -40,9 +41,9 @@ The retry parameters are:
 
 ## Error Codes You May See
 
-| Horizon Error | Meaning | Resolution |
-|---|---|---|
-| `tx_bad_auth` | Invalid ephemeral secret key | Check SDK key encryption and decryption |
-| `tx_insufficient_balance` | Account lacks XLM for payment | Verify account was properly funded |
-| `tx_too_late` | Transaction expired | Check network congestion; SDK will retry |
-| `tx_bad_seq` | Sequence number conflict | SDK will retry with fresh sequence |
+| Horizon Error             | Meaning                       | Resolution                               |
+| ------------------------- | ----------------------------- | ---------------------------------------- |
+| `tx_bad_auth`             | Invalid ephemeral secret key  | Check SDK key encryption and decryption  |
+| `tx_insufficient_balance` | Account lacks XLM for payment | Verify account was properly funded       |
+| `tx_too_late`             | Transaction expired           | Check network congestion; SDK will retry |
+| `tx_bad_seq`              | Sequence number conflict      | SDK will retry with fresh sequence       |

--- a/bridgelet-sdk-audit/integration-notes/payment-monitor-single-asset-limitation.md
+++ b/bridgelet-sdk-audit/integration-notes/payment-monitor-single-asset-limitation.md
@@ -1,0 +1,26 @@
+# Integration Note: Sweeping an Account That Was Never Paid
+
+> **For integrators** using the bridgelet-sdk sweep/claim flow.
+
+## Context
+
+The expected lifecycle is: create account → send payment → record payment → sweep. If you attempt to sweep an account that has never received a payment, the contract returns a `NO_PAYMENT_RECEIVED` error and the SDK maps it to HTTP 400.
+
+## What Happens
+
+```
+POST /accounts/{accountId}/sweep
+→ 400 "No payment received"
+   error_code: "NO_PAYMENT_RECEIVED"
+```
+
+The SDK will **not** retry this error. It is classified as terminal and non-retriable.
+
+## Why This Matters
+
+- If your integration has a race condition where the sweep is triggered before the payment monitor confirms the payment, you will get this error.
+- The payment monitor polls every 30 seconds by default (`PAYMENT_MONITOR_INTERVAL_MS`). If you trigger a sweep immediately after creating the account, the monitor may not have detected the payment yet.
+
+## Recommendation
+
+Wait for the `sweep.pending` webhook to fire before initiating the sweep. This webhook confirms the SDK has detected the payment and the account is ready for sweeping.

--- a/bridgelet-sdk-audit/integration-notes/sdk-side-error-mapping.md
+++ b/bridgelet-sdk-audit/integration-notes/sdk-side-error-mapping.md
@@ -1,0 +1,53 @@
+# Integration Note: SDK-Side Error Mapping
+
+> **For integrators** using the bridgelet-sdk to understand error responses.
+
+## Overview
+
+The bridgelet-sdk maps on-chain Soroban contract errors and Horizon transaction errors to structured HTTP responses. This note documents the mapping so you can programmatically handle errors in your integration.
+
+## Contract Errors (Soroban)
+
+These errors originate from the Soroban smart contract and are mapped by `contract-error.mapper.ts`:
+
+| Contract Error String | HTTP Status | Error Code | Retriable | Description |
+|---|---|---|---|---|
+| `AlreadySwept` | 410 | `ALREADY_SWEPT` | No | Account was already swept |
+| `AccountExpired` | 410 | `ACCOUNT_EXPIRED` | No | Account's expiry ledger passed on-chain |
+| `NoPaymentReceived` | 400 | `NO_PAYMENT_RECEIVED` | No | Payment was never recorded |
+| `InvalidStatus` | 409 | `INVALID_STATUS` | No | Contract not in expected state |
+| `AuthorizationFailed` | 403 | `AUTHORIZATION_FAILED` | No | Signature verification failed |
+| `UnauthorizedDestination` | 403 | `UNAUTHORIZED_DESTINATION` | No | Sweep destination not authorized |
+| `AccountAlreadySwept` | 410 | `ACCOUNT_ALREADY_SWEPT` | No | Variant of AlreadySwept |
+| Any other string | 500 | `UNKNOWN_CONTRACT_ERROR` | No | Catch-all — see note below |
+
+### Important Caveat
+
+Not all contract failures return a string. A malformed Ed25519 signature can cause a Wasm trap (panic) rather than returning a typed error. In this case, the SDK receives a raw `Error` that does not match any known string pattern and falls through to the catch-all 500. See `ed25519-signature-verification.md` for details.
+
+## Horizon Errors (Classic Operations)
+
+These errors originate from the Stellar network and are mapped by `horizon-error.mapper.ts`:
+
+| Horizon Error Code | HTTP Status | Error Code | Retriable | Description |
+|---|---|---|---|---|
+| `tx_bad_auth` | 401 | `TX_BAD_AUTH` | No | Signing key invalid |
+| `tx_insufficient_balance` | 402 | `TX_INSUFFICIENT_BALANCE` | No | Not enough XLM for operation |
+| `tx_too_late` | 408 | `TX_TOO_LATE` | Yes | Transaction expired before confirmation |
+| `tx_bad_seq` | 409 | `TX_BAD_SEQ` | Yes | Sequence number conflict |
+| Other | 502 | `HORIZON_ERROR` | Varies | Upstream Stellar network error |
+
+## Retry Behavior
+
+The SDK's sweep retry queue classifies errors as:
+- **Retriable**: `tx_too_late`, `tx_bad_seq`, network timeouts
+- **Terminal**: All contract errors, `tx_bad_auth`, `tx_insufficient_balance`
+
+Terminal errors are **never** retried and result in an immediate `FAILED` status with an `sweep.failed` webhook.
+
+## Best Practices
+
+1. **Always check `error_code`** in the response body, not just the HTTP status.
+2. **Do not retry terminal errors** — they will fail again.
+3. **For `PARTIAL_SWEEP`** status, the SDK handles recovery automatically via the retry queue.
+4. **Subscribe to webhooks** (`sweep.partial`, `sweep.failed`, `sweep.completed`) rather than polling for status.

--- a/bridgelet-sdk-audit/integration-notes/sdk-side-error-mapping.md
+++ b/bridgelet-sdk-audit/integration-notes/sdk-side-error-mapping.md
@@ -10,16 +10,16 @@ The bridgelet-sdk maps on-chain Soroban contract errors and Horizon transaction 
 
 These errors originate from the Soroban smart contract and are mapped by `contract-error.mapper.ts`:
 
-| Contract Error String | HTTP Status | Error Code | Retriable | Description |
-|---|---|---|---|---|
-| `AlreadySwept` | 410 | `ALREADY_SWEPT` | No | Account was already swept |
-| `AccountExpired` | 410 | `ACCOUNT_EXPIRED` | No | Account's expiry ledger passed on-chain |
-| `NoPaymentReceived` | 400 | `NO_PAYMENT_RECEIVED` | No | Payment was never recorded |
-| `InvalidStatus` | 409 | `INVALID_STATUS` | No | Contract not in expected state |
-| `AuthorizationFailed` | 403 | `AUTHORIZATION_FAILED` | No | Signature verification failed |
-| `UnauthorizedDestination` | 403 | `UNAUTHORIZED_DESTINATION` | No | Sweep destination not authorized |
-| `AccountAlreadySwept` | 410 | `ACCOUNT_ALREADY_SWEPT` | No | Variant of AlreadySwept |
-| Any other string | 500 | `UNKNOWN_CONTRACT_ERROR` | No | Catch-all — see note below |
+| Contract Error String     | HTTP Status | Error Code                 | Retriable | Description                             |
+| ------------------------- | ----------- | -------------------------- | --------- | --------------------------------------- |
+| `AlreadySwept`            | 410         | `ALREADY_SWEPT`            | No        | Account was already swept               |
+| `AccountExpired`          | 410         | `ACCOUNT_EXPIRED`          | No        | Account's expiry ledger passed on-chain |
+| `NoPaymentReceived`       | 400         | `NO_PAYMENT_RECEIVED`      | No        | Payment was never recorded              |
+| `InvalidStatus`           | 409         | `INVALID_STATUS`           | No        | Contract not in expected state          |
+| `AuthorizationFailed`     | 403         | `AUTHORIZATION_FAILED`     | No        | Signature verification failed           |
+| `UnauthorizedDestination` | 403         | `UNAUTHORIZED_DESTINATION` | No        | Sweep destination not authorized        |
+| `AccountAlreadySwept`     | 410         | `ACCOUNT_ALREADY_SWEPT`    | No        | Variant of AlreadySwept                 |
+| Any other string          | 500         | `UNKNOWN_CONTRACT_ERROR`   | No        | Catch-all — see note below              |
 
 ### Important Caveat
 
@@ -29,17 +29,18 @@ Not all contract failures return a string. A malformed Ed25519 signature can cau
 
 These errors originate from the Stellar network and are mapped by `horizon-error.mapper.ts`:
 
-| Horizon Error Code | HTTP Status | Error Code | Retriable | Description |
-|---|---|---|---|---|
-| `tx_bad_auth` | 401 | `TX_BAD_AUTH` | No | Signing key invalid |
-| `tx_insufficient_balance` | 402 | `TX_INSUFFICIENT_BALANCE` | No | Not enough XLM for operation |
-| `tx_too_late` | 408 | `TX_TOO_LATE` | Yes | Transaction expired before confirmation |
-| `tx_bad_seq` | 409 | `TX_BAD_SEQ` | Yes | Sequence number conflict |
-| Other | 502 | `HORIZON_ERROR` | Varies | Upstream Stellar network error |
+| Horizon Error Code        | HTTP Status | Error Code                | Retriable | Description                             |
+| ------------------------- | ----------- | ------------------------- | --------- | --------------------------------------- |
+| `tx_bad_auth`             | 401         | `TX_BAD_AUTH`             | No        | Signing key invalid                     |
+| `tx_insufficient_balance` | 402         | `TX_INSUFFICIENT_BALANCE` | No        | Not enough XLM for operation            |
+| `tx_too_late`             | 408         | `TX_TOO_LATE`             | Yes       | Transaction expired before confirmation |
+| `tx_bad_seq`              | 409         | `TX_BAD_SEQ`              | Yes       | Sequence number conflict                |
+| Other                     | 502         | `HORIZON_ERROR`           | Varies    | Upstream Stellar network error          |
 
 ## Retry Behavior
 
 The SDK's sweep retry queue classifies errors as:
+
 - **Retriable**: `tx_too_late`, `tx_bad_seq`, network timeouts
 - **Terminal**: All contract errors, `tx_bad_auth`, `tx_insufficient_balance`
 


### PR DESCRIPTION
This PR adds four integration notes to bridgelet-sdk-audit/integration-notes/:

1. **ed25519-signature-verification.md** (#292): Documents the gap where a malformed Ed25519 signature can trigger a Wasm trap (500) instead of a structured `AuthorizationFailed` (403), making it indistinguishable from other contract errors.

2. **payment-monitor-single-asset-limitation.md** (#293): Explains the race condition where sweeping before the payment monitor confirms a payment returns `NO_PAYMENT_RECEIVED`, and recommends waiting for the `sweep.pending` webhook.

3. **partial-sweep-recovery.md** (#294): Documents the `PARTIAL_SWEEP` recovery flow — automatic retry queue with `skipContractAuth`, exponential backoff, and what happens if the service restarts mid-retry.

4. **sdk-side-error-mapping.md** (#295): Comprehensive reference mapping all contract and Horizon errors to HTTP status codes, error codes, and retry classification.

Closes #292, Closes #293, Closes #294, Closes #295