### PR TITLE
docs: add operational runbooks for metrics, resolution, and reconciliation

### DIFF
--- a/bridgelet-sdk-audit/runbooks/audit-sweep-related-metrics.md
+++ b/bridgelet-sdk-audit/runbooks/audit-sweep-related-metrics.md
@@ -1,0 +1,21 @@
+# Investigating Slow Sweep Flow using soroban_rpc_latency_seconds
+
+## Overview
+
+When the `soroban_rpc_latency_seconds` metric shows anomalous spikes specifically during the `Sweep` operation, it indicates a bottleneck between the SDK and the Soroban RPC node.
+
+## Steps
+
+1. **Verify Metric Dimensions**
+   Check the `method` label on the metric (e.g. `simulateTransaction` vs `sendTransaction`).
+   - If `simulateTransaction` is slow: The RPC node might be overloaded, or the contract execution itself is too expensive.
+   - If `sendTransaction` is slow: Network latency or node mempool congestion.
+
+2. **Check Soroban RPC Node Health**
+   Ping the RPC node's `/health` endpoint. Look for high resource usage (CPU/memory) on the node provider dashboard.
+
+3. **Analyse Transaction Payload**
+   Review the specific sweep transaction. Are there unusually large lists of accounts being merged? Consider chunking the sweeps into smaller batches.
+
+4. **Fallback & Retry Logic**
+   Verify that the SDK's internal exponential backoff is functioning and not endlessly retrying a fundamentally broken transaction.

--- a/bridgelet-sdk-audit/runbooks/handle-overlapping-payment-monitor-ticks.md
+++ b/bridgelet-sdk-audit/runbooks/handle-overlapping-payment-monitor-ticks.md
@@ -1,0 +1,25 @@
+# Handling Overlapping Payment Monitor Ticks
+
+## Context
+
+The payment monitor runs on a `cron` or `setInterval` tick. If Horizon is slow, or the downstream database is locked, a tick may take longer than the interval duration, causing the next tick to overlap.
+
+## Symptoms
+
+- Duplicate payment processing logs.
+- Database deadlock exceptions on the `payments` table.
+- High memory usage on the SDK worker instance.
+
+## Remediation Steps
+
+1. **Verify Mutex/Locking Mechanism**
+   Ensure the distributed lock (e.g. Redis `SETNX` or DB advisory lock) is functioning. The second tick should gracefully skip if the lock is held.
+
+2. **Check Lock Expiry**
+   If the first tick crashed without releasing the lock, check the lock TTL. Is it too long? Force release the lock manually via Redis/DB if it's confirmed dead.
+
+3. **Scale the Worker**
+   If a single tick consistently takes too long, investigate pagination. Ensure the monitor is only fetching small batches (e.g., 50 records) per tick rather than unbounded queries.
+
+4. **Alert Muting**
+   If this is a known transient network issue, temporarily suppress PagerDuty alerts for "Overlap Detected" until the network stabilizes.

--- a/bridgelet-sdk-audit/runbooks/metrics-overview.md
+++ b/bridgelet-sdk-audit/runbooks/metrics-overview.md
@@ -1,0 +1,9 @@
+# Metrics Overview
+
+This document provides a high-level summary of the critical metrics to monitor for the Bridgelet SDK.
+
+## Core Metrics
+
+- `soroban_rpc_latency_seconds`: Latency of RPC calls.
+- `bridgelet_payment_monitor_ticks_total`: Number of monitor ticks executed.
+- `bridgelet_sweep_failures_total`: Count of failed sweep operations.

--- a/bridgelet-sdk-audit/runbooks/reconcile-database-vs-chain-state.md
+++ b/bridgelet-sdk-audit/runbooks/reconcile-database-vs-chain-state.md
@@ -1,0 +1,34 @@
+# Reconciling Database vs Chain State
+
+## Overview
+
+Due to transient network failures or SDK crashes, the internal database (e.g., recorded payments or account balances) might drift from the actual on-chain state on the Stellar network.
+
+## Procedure
+
+1. **Pause Ingestion**
+   Temporarily pause the SDK's payment monitors/webhooks to ensure state doesn't mutate while reconciling.
+
+2. **Run the Reconciliation Script**
+   Execute the built-in reconciliation tool:
+
+   ```bash
+   npm run sdk:reconcile -- --ledger <LAST_KNOWN_GOOD_LEDGER>
+   ```
+
+3. **Analyze the Diff**
+   The script will output a JSON file containing the discrepancies.
+   - Look for missing payments (exist on chain, not in DB).
+   - Look for false positives (exist in DB, but transaction actually failed on chain).
+
+4. **Apply Fixes**
+   For missing payments, use the script's backfill command:
+
+   ```bash
+   npm run sdk:reconcile:apply --file diff.json
+   ```
+
+   For false positives, manually reverse the downstream actions (e.g. deduct balances) and mark the DB record as `FAILED_ON_CHAIN`.
+
+5. **Resume Ingestion**
+   Once the state is verified, restart the payment monitors.

--- a/bridgelet-sdk-audit/runbooks/validate-asset-address-resolution.md
+++ b/bridgelet-sdk-audit/runbooks/validate-asset-address-resolution.md
@@ -1,0 +1,21 @@
+# Validating resolveAssetAddress() Output
+
+## Objective
+
+When a new or unusual asset (e.g. an unverified token or bridged asset) is added to the system, it is critical to verify that `resolveAssetAddress()` correctly maps the asset code/issuer to the correct Soroban contract address.
+
+## Steps
+
+1. **Invoke the Resolver Directly**
+   Run the SDK's `resolveAssetAddress(assetCode, issuer)` function in a REPL or test script against the target network (Testnet/Mainnet).
+
+2. **Cross-Check with Horizon**
+   Use Horizon API to fetch the asset's TOML file or trustlines. Ensure the contract ID matches what the network reports as the wrapper contract for that classic asset.
+
+3. **Verify Contract State**
+   Query the resolved contract address on Stellar Expert or via `soroban contract inspect`.
+   - Does it implement the standard token interface?
+   - Is it the exact contract ID expected by the bridge?
+
+4. **Update Whitelist (if applicable)**
+   If the asset is valid but was previously rejected, ensure the internal asset whitelist config is updated and deployed.


### PR DESCRIPTION
Introduced operational runbooks to handle edge cases and debugging scenarios related to sweeps, asset resolution, and state reconciliation.

Highlights:
- Created runbook for investigating slow sweep flows via RPC metrics
- Created runbook for validating asset address resolution
- Created runbook for handling overlapping payment monitor ticks
- Created runbook for manual DB vs Chain state reconciliation
- Added metrics overview documentation

close #311
close #310
close #309
close #308