### PR TITLE
docs: add operational runbooks for triage and recovery

### DIFF
--- a/bridgelet-sdk-audit/runbooks/backfill-missed-payments.md
+++ b/bridgelet-sdk-audit/runbooks/backfill-missed-payments.md
@@ -1,0 +1,20 @@
+# Backfilling Missed Payments
+
+## Context
+
+If an ephemeral account received a payment in an asset other than the expected one (e.g., USDC instead of XLM), the primary payment monitor might miss it due to strict asset filtering, leaving the invoice in a pending state.
+
+## Procedure
+
+1. **Verify the Transaction on Chain**
+   Ensure the user actually sent the payment to the correct ephemeral account, even if it was the wrong asset.
+
+2. **Run the Backfill Script**
+   Use the manual backfill tool, providing the specific transaction hash:
+
+   ```bash
+   npm run sdk:backfill -- --tx <TRANSACTION_HASH> --override-asset-check true
+   ```
+
+3. **Verify Downstream Processing**
+   Check the database to ensure the payment is now recorded. If the amount in the wrong asset is insufficient, mark the invoice as `PARTIALLY_PAID` or `INVALID_ASSET` in the admin dashboard.

--- a/bridgelet-sdk-audit/runbooks/diagnose-transaction-polling-timeout.md
+++ b/bridgelet-sdk-audit/runbooks/diagnose-transaction-polling-timeout.md
@@ -1,0 +1,19 @@
+# Diagnosing a waitForTransaction() Timeout
+
+## Overview
+
+When `waitForTransaction()` times out, it means the transaction was submitted to the network but Horizon did not report its completion within the expected timeframe.
+
+## Diagnosis Steps
+
+1. **Check Mempool / Network Load**
+   A timeout often indicates network congestion. The transaction might still be in the mempool waiting for consensus.
+
+2. **Check Transaction Hash on Stellar Expert**
+   Look up the transaction hash manually.
+   - If it eventually succeeded: The SDK's timeout was too aggressive. Consider increasing the timeout duration.
+   - If it failed: The SDK missed the error response from Horizon. Investigate Horizon logs.
+   - If it doesn't exist: The transaction was dropped by the network (e.g., fee too low).
+
+3. **Handling Dropped Transactions**
+   If the transaction was dropped, you can safely resubmit it with a higher fee, provided you use the same sequence number to ensure idempotency.

--- a/bridgelet-sdk-audit/runbooks/recover-from-partial-account-creation-failure.md
+++ b/bridgelet-sdk-audit/runbooks/recover-from-partial-account-creation-failure.md
@@ -1,0 +1,26 @@
+# Recovering from a Partial Account Creation Failure
+
+## Context
+
+A hybrid application might create a classic Stellar account on Horizon, but fail in a subsequent step to register that account's metadata with a Soroban smart contract. This leaves the account in a "partially created" state.
+
+## Identification
+
+- The account exists on Stellar Expert.
+- Querying the Soroban contract for the account yields a "Not Found" error.
+- The downstream database marks the account as `PENDING_SOROBAN_REGISTRATION`.
+
+## Remediation
+
+1. **Verify Balances**
+   Ensure the account was properly funded with the base reserve during the Horizon step.
+
+2. **Re-run the Registration Step**
+   Use the SDK's retry utility to solely execute the Soroban registration transaction:
+
+   ```bash
+   npm run sdk:retry:soroban-registration -- --accountId <G_ADDRESS>
+   ```
+
+3. **Verify State**
+   Confirm the script successfully registered the account by querying the contract state again. The downstream DB should automatically flip to `ACTIVE` upon success.

--- a/bridgelet-sdk-audit/runbooks/triage-index.md
+++ b/bridgelet-sdk-audit/runbooks/triage-index.md
@@ -1,0 +1,8 @@
+# Triage Index
+
+This document serves as an index for various triage scenarios.
+
+- [Webhook Delivery Failure Triage](./webhook-delivery-failure-triage.md)
+- [Diagnose Transaction Polling Timeout](./diagnose-transaction-polling-timeout.md)
+- [Backfill Missed Payments](./backfill-missed-payments.md)
+- [Recover from Partial Account Creation Failure](./recover-from-partial-account-creation-failure.md)

--- a/bridgelet-sdk-audit/runbooks/webhook-delivery-failure-triage.md
+++ b/bridgelet-sdk-audit/runbooks/webhook-delivery-failure-triage.md
@@ -1,0 +1,20 @@
+# Triaging Webhook Delivery Failures
+
+## Overview
+
+When the SDK fails to deliver a webhook to an integrator multiple times (triggering Dead Letter Queue or PagerDuty alerts), follow this process to diagnose and resolve.
+
+## Steps
+
+1. **Verify Integrator Endpoint**
+   Use curl to send an empty `POST` to the integrator's registered webhook URL.
+   - If HTTP 4xx/5xx: The integrator's server is down or misconfigured. Reach out to them.
+   - If Timeout: Check if their firewall is blocking our NAT Gateway IP.
+
+2. **Check Signature Mismatches**
+   If the integrator returns HTTP 401/403:
+   - Ask them to verify their secret matches the one registered in our database.
+   - Verify that they are parsing the raw body correctly before signature calculation (frameworks like Express sometimes alter the raw body buffer).
+
+3. **Re-queue Dead Letters**
+   Once the issue is resolved on the integrator's end, manually trigger a redelivery of the failed webhooks from the DLQ.


### PR DESCRIPTION
Introduced operational runbooks to handle edge cases and debugging scenarios related to webhook delivery, transaction timeouts, and partial state failures.

Highlights:
- Created runbook for triaging webhook delivery failures
- Created runbook for diagnosing transaction polling timeouts
- Created runbook for backfilling missed payments
- Created runbook for recovering from partial account creation failures
- Added a triage index

close #307
close #306
close #305
close #304