### PR TITLE
docs: add glossary entries for SDK audit knowledge base

### DIFF
--- a/bridgelet-sdk-audit/glossary/README.md
+++ b/bridgelet-sdk-audit/glossary/README.md
@@ -1,0 +1,12 @@
+# Bridgelet SDK Glossary
+
+This directory contains definitions and conceptual overviews for key terminology and architecture decisions within the Bridgelet SDK.
+
+## Available Entries
+
+- [Stroop Amount Parsing](./stroop-amount-parsing.md)
+- [Asset Address Resolution](./asset-address-resolution.md)
+- [Horizon vs Soroban RPC](./horizon-vs-soroban-rpc.md)
+- [Webhook Event Types](./webhook-event-types.md)
+
+These entries serve as a knowledge base for internal audits and onboarding.

--- a/bridgelet-sdk-audit/glossary/asset-address-resolution.md
+++ b/bridgelet-sdk-audit/glossary/asset-address-resolution.md
@@ -1,0 +1,13 @@
+# Asset Address Resolution
+
+## Definition
+
+Asset Address Resolution is the process of mapping a classic Stellar Asset (defined by an alphanumeric Code and an Issuer Public Key) to its corresponding Soroban Smart Contract ID (a `C...` address).
+
+## Implementation
+
+The `AssetResolver` module securely derives the contract address locally using the `xdr.Asset` to `xdr.ContractId` SHA-256 derivation rules defined by CAP-46, without needing an RPC roundtrip.
+
+```typescript
+const contractId = resolveAssetAddress('USDC', 'GABC123...');
+```

--- a/bridgelet-sdk-audit/glossary/horizon-vs-soroban-rpc.md
+++ b/bridgelet-sdk-audit/glossary/horizon-vs-soroban-rpc.md
@@ -1,0 +1,19 @@
+# Horizon vs Soroban RPC
+
+## Horizon
+
+The Horizon API is the RESTful interface for the classic Stellar network.
+**In the Bridgelet SDK, Horizon is used exclusively for:**
+
+- Monitoring incoming payments (`/payments` endpoint).
+- Submitting account creation transactions (funding base reserves).
+- Fetching historical ledger data.
+
+## Soroban RPC
+
+The Soroban RPC is a JSON-RPC interface designed specifically for interacting with Soroban smart contracts.
+**In the Bridgelet SDK, Soroban RPC is used exclusively for:**
+
+- Simulating and submitting sweep transactions.
+- Querying contract state (e.g. reading balances from a custom token contract).
+- Fetching contract events.

--- a/bridgelet-sdk-audit/glossary/stroop-amount-parsing.md
+++ b/bridgelet-sdk-audit/glossary/stroop-amount-parsing.md
@@ -1,0 +1,16 @@
+# Stroop Amount Parsing
+
+## Definition
+
+A **Stroop** is the smallest unit of a Stellar lumen (XLM) and most Soroban tokens. 1 XLM = 10,000,000 stroops (10^7).
+
+## Usage in Bridgelet SDK
+
+Horizon typically returns amounts as decimal strings (e.g., `"1.5000000"`). Soroban smart contracts require amounts to be passed as `i128` stroops.
+
+The SDK uses the `parseStroops()` utility function to safely convert these string values into BigInt stroops without floating-point precision loss.
+
+```typescript
+const decimalAmount = '1.5';
+const stroops = parseStroops(decimalAmount); // Returns BigInt(15000000)
+```

--- a/bridgelet-sdk-audit/glossary/webhook-event-types.md
+++ b/bridgelet-sdk-audit/glossary/webhook-event-types.md
@@ -1,0 +1,10 @@
+# Webhook Event Types
+
+The Bridgelet SDK emits the following webhook event types to integrators:
+
+- `payment.detected`: Emitted when an incoming payment is seen on the network but is pending confirmation or balance threshold checks.
+- `payment.confirmed`: Emitted when a payment is fully confirmed and balances are ready for sweeping.
+- `payment.failed`: Emitted if a detected payment is deemed invalid (e.g., wrong asset).
+- `sweep.initiated`: Emitted when a sweep transaction is submitted to the network.
+- `sweep.completed`: Emitted when a sweep is confirmed successful on-chain.
+- `sweep.failed`: Emitted if a sweep transaction fails or times out.


### PR DESCRIPTION
Introduced foundational glossary entries to establish a shared vocabulary for internal SDK audits and onboarding.

Highlights:
- Created glossary entry for Stroop amount parsing
- Created glossary entry for Asset address resolution
- Created glossary entry differentiating Horizon and Soroban RPC
- Created glossary entry defining Webhook event types
- Added a glossary index README

close #289
close #288
close #287
close #283