### PR TITLE
docs: WaitForTransaction()'s poll-until-confirmed pattern

### DIFF
--- a/bridgelet-sdk-audit/glossary/error-string-matching.md
+++ b/bridgelet-sdk-audit/glossary/error-string-matching.md
@@ -16,10 +16,10 @@ The pattern involves the following steps:
 
 The following strings are currently matched on:
 
-*   `AlreadySwept`
-*   `AccountExpired`
-*   `InvalidStatus`
-*   `DuplicateAsset`
+- `AlreadySwept`
+- `AccountExpired`
+- `InvalidStatus`
+- `DuplicateAsset`
 
 ## Brittleness and Risk
 

--- a/bridgelet-sdk-audit/glossary/error-string-matching.md
+++ b/bridgelet-sdk-audit/glossary/error-string-matching.md
@@ -1,0 +1,26 @@
+# Error String Matching for Contract Errors
+
+## Purpose
+
+This document describes the pattern used in `executeSweep()`, `expireAccount()`, and `processPayment()` to classify contract failures.
+
+## Pattern
+
+The pattern involves the following steps:
+
+1.  The RPC error result from a contract call is received.
+2.  The error result is converted to a string using `JSON.stringify(errorResult)`.
+3.  A substring match is performed on the resulting string to check for the presence of a specific contract error name.
+
+## Matched Error Strings
+
+The following strings are currently matched on:
+
+*   `AlreadySwept`
+*   `AccountExpired`
+*   `InvalidStatus`
+*   `DuplicateAsset`
+
+## Brittleness and Risk
+
+This pattern is inherently brittle. It relies on the string representation of the error, which can change unexpectedly. For a more detailed analysis of the risks associated with this pattern, please refer to the corresponding postmortem entry.

--- a/bridgelet-sdk-audit/glossary/transaction-polling.md
+++ b/bridgelet-sdk-audit/glossary/transaction-polling.md
@@ -1,0 +1,19 @@
+# `waitForTransaction()`'s poll-until-confirmed pattern
+
+**Purpose:** Document the retry loop `StellarService.waitForTransaction()` uses after every `sendTransaction()` call.
+
+## Polling Loop Details
+
+`StellarService.waitForTransaction()` employs a fixed polling loop to check the status of a submitted transaction. The key characteristics of this loop are:
+
+*   **Attempts:** 10 attempts.
+*   **Interval:** 2 seconds between each attempt.
+*   **Total Time:** This results in a total polling duration of approximately 20 seconds.
+
+## Usage
+
+Every state-mutating on-chain call within the `StellarService` utilizes this `waitForTransaction()` helper function. This ensures a consistent mechanism for handling transaction submissions and confirmations.
+
+## Timeout Behavior
+
+If the polling loop completes all 10 attempts without the transaction reaching a terminal status (e.g., success or failure), the caller will receive a generic timeout `Error`. This indicates that the transaction confirmation could not be secured within the allotted ~20 second window.

--- a/bridgelet-sdk-audit/glossary/transaction-polling.md
+++ b/bridgelet-sdk-audit/glossary/transaction-polling.md
@@ -6,9 +6,9 @@
 
 `StellarService.waitForTransaction()` employs a fixed polling loop to check the status of a submitted transaction. The key characteristics of this loop are:
 
-*   **Attempts:** 10 attempts.
-*   **Interval:** 2 seconds between each attempt.
-*   **Total Time:** This results in a total polling duration of approximately 20 seconds.
+- **Attempts:** 10 attempts.
+- **Interval:** 2 seconds between each attempt.
+- **Total Time:** This results in a total polling duration of approximately 20 seconds.
 
 ## Usage
 


### PR DESCRIPTION
Closes #278
Polling Loop Details

`StellarService.waitForTransaction()` employs a fixed polling loop to check the status of a submitted transaction. The key characteristics of this loop are:

*   **Attempts:** 10 attempts.
*   **Interval:** 2 seconds between each attempt.
*   **Total Time:** This results in a total polling duration of approximately 20 seconds

Closes #279