### PR TITLE
docs: add postmortems for monitor ticks, webhook ordering, and parsing coupling

### DIFF
--- a/bridgelet-sdk-audit/postmortems/getinfo-parsing-coupling.md
+++ b/bridgelet-sdk-audit/postmortems/getinfo-parsing-coupling.md
@@ -1,0 +1,13 @@
+# Postmortem: Tight Coupling in getAccountInfo() Parsing
+
+## Issue Summary
+
+When the Soroban smart contract added a new optional field to the `AccountInfo` struct, the SDK's `getAccountInfo()` method started throwing unhandled XDR decoding errors in production.
+
+## Root Cause
+
+The `getAccountInfo()` implementation relied on a hand-written array index-based parser to decode the XDR response from the contract. The addition of a field shifted the expected tuple indices, breaking backward compatibility even though the field was optional in Rust.
+
+## Resolution
+
+Refactored the SDK to use auto-generated TypeScript bindings (via `soroban contract bindings typescript`) instead of manual XDR parsing, which gracefully handles optional struct fields and provides compile-time type safety.

--- a/bridgelet-sdk-audit/postmortems/overlapping-payment-monitor-ticks.md
+++ b/bridgelet-sdk-audit/postmortems/overlapping-payment-monitor-ticks.md
@@ -1,0 +1,13 @@
+# Postmortem: Overlapping Payment Monitor Ticks
+
+## Issue Summary
+
+The `setInterval`-based polling approach for Horizon payments allowed multiple overlapping requests when the RPC latency spiked. This caused memory leaks and duplicate payment handling logic execution.
+
+## Root Cause
+
+`setInterval` schedules executions at fixed intervals regardless of whether the previous execution has finished. During a Horizon latency spike, ticks accumulated in the event loop.
+
+## Resolution
+
+Migrated the polling mechanism from `setInterval` to a recursive `setTimeout` pattern combined with a distributed advisory lock to guarantee strict sequential execution and backpressure handling.

--- a/bridgelet-sdk-audit/postmortems/postmortem-template.md
+++ b/bridgelet-sdk-audit/postmortems/postmortem-template.md
@@ -1,0 +1,18 @@
+# Postmortem Template
+
+## Issue Summary
+
+[Provide a brief 1-2 sentence summary of what went wrong and the user impact.]
+
+## Root Cause
+
+[Explain the technical root cause of the issue in detail.]
+
+## Resolution
+
+[Explain the fix implemented to resolve the issue and prevent future occurrences.]
+
+## Action Items
+
+- [ ] List any follow-up tasks (e.g., adding monitors, refactoring).
+- [ ] ...

--- a/bridgelet-sdk-audit/postmortems/postmortems-index.md
+++ b/bridgelet-sdk-audit/postmortems/postmortems-index.md
@@ -1,0 +1,9 @@
+# Postmortems Index
+
+This directory archives postmortems and lessons learned from past incidents involving the Bridgelet SDK.
+
+- [Overlapping Payment Monitor Ticks](./overlapping-payment-monitor-ticks.md)
+- [Webhook vs Confirmation Ordering](./webhook-vs-confirmation-ordering.md)
+- [Tight Coupling in getAccountInfo() Parsing](./getinfo-parsing-coupling.md)
+
+Use the [Postmortem Template](./postmortem-template.md) to add new entries.

--- a/bridgelet-sdk-audit/postmortems/webhook-vs-confirmation-ordering.md
+++ b/bridgelet-sdk-audit/postmortems/webhook-vs-confirmation-ordering.md
@@ -1,0 +1,13 @@
+# Postmortem: Webhook vs Confirmation Ordering
+
+## Issue Summary
+
+Under heavy load, integrators reported receiving `sweep.completed` webhooks before the corresponding transaction was fully confirmed as successful by their own Horizon nodes, causing internal state mismatch.
+
+## Root Cause
+
+The SDK was emitting the `sweep.completed` webhook immediately after receiving the `SUCCESS` status from the Soroban RPC `sendTransaction` endpoint. However, RPC nodes can sometimes report success slightly before the ledger is fully finalized across all nodes in the network.
+
+## Resolution
+
+Added a configuration toggle `webhook_delay_ledgers` (default: 1) which instructs the SDK to wait for at least one additional ledger close before emitting terminal webhooks, ensuring global consistency.


### PR DESCRIPTION
Introduced postmortems to document recent production incidents and lessons learned.

Highlights:
- Created postmortem for overlapping payment monitor ticks
- Created postmortem for webhook vs confirmation ordering
- Created postmortem for tight coupling in getAccountInfo() parsing
- Added postmortem template
- Added postmortems index

close #337
close #336
close #334
close #336