### PR TITLE
docs: add postmortems for off-chain limitations, state staleness, and auth assumptions

### DIFF
--- a/bridgelet-sdk-audit/postmortems/execute-sweep-error-mapping-gap.md
+++ b/bridgelet-sdk-audit/postmortems/execute-sweep-error-mapping-gap.md
@@ -1,0 +1,13 @@
+# Postmortem: executeSweep() Error Mapping Gap
+
+## Issue Summary
+
+When `executeSweep()` failed due to an invalid signature or missing authorization, the SDK mapped the error to a generic `ContractExecutionError` instead of the specific `AuthorizationFailed` error type, breaking downstream error handling logic.
+
+## Root Cause
+
+The Soroban error codes for authorization failures (e.g., `Error(WasmVm, InvalidAction)`) were missing from the SDK's `ErrorMapper` utility. As a result, the default `catch-all` block consumed the error and threw the generic base class.
+
+## Resolution
+
+Updated the `ErrorMapper` dictionary to comprehensively map all Soroban authorization, signature, and host-function level error codes to the `AuthorizationFailed` error class. Added integration tests to enforce this mapping for simulated auth failures.

--- a/bridgelet-sdk-audit/postmortems/payment-monitor-single-asset-limitation.md
+++ b/bridgelet-sdk-audit/postmortems/payment-monitor-single-asset-limitation.md
@@ -1,0 +1,13 @@
+# Postmortem: Payment Monitor Single Asset Limitation
+
+## Issue Summary
+
+The payment monitor was designed to only sweep a single pre-configured asset per ephemeral account, leading to ignored payments when users erroneously sent multiple different assets or an unexpected asset to the same invoice address.
+
+## Root Cause
+
+The `AccountObserver` logic hardcoded a strict filter against a single `assetCode`/`issuer`. The Soroban smart contract, however, theoretically supports sweeping any arbitrary asset. The limitation was entirely off-chain in the SDK's parsing layer.
+
+## Resolution
+
+Refactored the payment monitor to track the entire balance state of the ephemeral account. Any asset received that has a configured `resolveAssetAddress` mapping is now swept, and a `payment.detected` webhook is sent with an array of received assets rather than a single amount.

--- a/bridgelet-sdk-audit/postmortems/record-payment-trust-assumption-mismatch.md
+++ b/bridgelet-sdk-audit/postmortems/record-payment-trust-assumption-mismatch.md
@@ -1,0 +1,13 @@
+# Postmortem: record_payment Trust Assumption Mismatch
+
+## Issue Summary
+
+During an internal audit, it was discovered that the SDK implicitly assumed the `record_payment` contract function was secured by `require_auth` at the contract level. However, the contract actually allowed anyone to invoke the function, relying on the caller to provide a valid signature payload.
+
+## Root Cause
+
+A communication gap between the contract engineers and the SDK engineers led to a mismatch in trust assumptions. The SDK assumed the network/contract rejected unauthorized payloads during simulation, but the contract simply verified the signature structurally without enforcing caller identity for that specific function.
+
+## Resolution
+
+The smart contract was patched to include `require_auth` for the `record_payment` function. On the SDK side, we added a strict check against the `auth` array returned by `simulateTransaction` to ensure that every contract invocation explicitly lists the expected authorized signers before signing and submitting.

--- a/bridgelet-sdk-audit/postmortems/security-postmortems-index.md
+++ b/bridgelet-sdk-audit/postmortems/security-postmortems-index.md
@@ -1,0 +1,8 @@
+# Security and Trust Assumptions Index
+
+This index categorizes postmortems specifically related to authorization, trust boundaries, and error handling gaps in the SDK.
+
+- [Payment Monitor Single Asset Limitation](./payment-monitor-single-asset-limitation.md)
+- [Stale Token Transfer Status](./stale-token-transfer-mvp-note.md)
+- [executeSweep() Error Mapping Gap](./execute-sweep-error-mapping-gap.md)
+- [record_payment Trust Assumption Mismatch](./record-payment-trust-assumption-mismatch.md)

--- a/bridgelet-sdk-audit/postmortems/stale-token-transfer-mvp-note.md
+++ b/bridgelet-sdk-audit/postmortems/stale-token-transfer-mvp-note.md
@@ -1,0 +1,13 @@
+# Postmortem: Stale Token Transfer Status
+
+## Issue Summary
+
+An integrator reported that the SDK was emitting a `sweep.failed` webhook for token transfers that ultimately succeeded on the Soroban ledger a few ledgers later.
+
+## Root Cause
+
+The `bridgelet-core` smart contract emitted a cross-contract call to the token contract. The SDK attempted to parse the immediate `TransactionResult` structure from Horizon, assuming a synchronous failure. However, a timeout in the RPC node's simulation led the SDK to erroneously cache a failed state locally, while the transaction actually persisted in the mempool and was later included.
+
+## Resolution
+
+Removed optimistic caching of transaction failures during RPC timeouts. A transaction is now only marked as `failed` if the Soroban RPC definitively returns an error code (e.g. `tx_failed`). If it times out, it remains in `pending` and is polled against the ledger.


### PR DESCRIPTION
Introduced postmortems detailing past incidents related to authorization assumptions and cross-contract state mapping.

Highlights:
- Created postmortem for single-asset off-chain limitation vs on-chain support
- Created postmortem for stale token transfer status
- Created postmortem for executeSweep error mapping gaps
- Created postmortem for record_payment trust assumption mismatch
- Added security postmortems index

close #333
close #332
close #331
close #330