### PR TITLE
docs: add postmortem for Horizon-Soroban non-atomicity and MVP-note accuracy checklist

### DIFF
--- a/bridgelet-sdk-audit/checklists/README.md
+++ b/bridgelet-sdk-audit/checklists/README.md
@@ -8,5 +8,6 @@ This directory contains standardized checklists used during internal code audits
 - [Error Mapping Completeness](./error-mapping-completeness-checklist.md)
 - [Account Expiry Flow](./account-expiry-flow-checklist.md)
 - [Sweep Execution Flow](./sweep-execution-flow-checklist.md)
+- [MVP Note Accuracy](./mvp-note-accuracy-checklist.md)
 
 Please ensure these checklists are completed during PR reviews for relevant components.

--- a/bridgelet-sdk-audit/checklists/mvp-note-accuracy-checklist.md
+++ b/bridgelet-sdk-audit/checklists/mvp-note-accuracy-checklist.md
@@ -1,0 +1,47 @@
+# MVP Note and Doc-Comment Accuracy Checklist
+
+## Purpose
+
+Periodic verification that every `⚠️ MVP Note` comment in the contract-consumption layer still reflects the actual behavior of `bridgelet-core` and the SDK's interaction with it. Run this checklist after any bridgelet-core contract upgrade, redeployment, or SDK refactor touching the Stellar service layer.
+
+## MVP Note Inventory
+
+All MVP notes reside in `src/modules/stellar/stellar.service.ts`.
+
+### 1. Horizon-Soroban Non-Atomicity (`createEphemeralAccount`)
+
+- [ ] Confirm that `createEphemeralAccount()` still performs Horizon `CreateAccount` and Soroban `initialize()` as two separate transactions.
+- [ ] Confirm that the SDK still throws an error (does not persist a DB record) when `initialize()` fails after `CreateAccount` succeeds.
+- [ ] Confirm that Issue #15 tracking the compensation strategy is still open or that a resolution has been shipped.
+- [ ] Confirm the MVP note's description of the failure window (unrestricted funded account on-chain) matches the current on-chain behavior.
+
+### 2. Token Transfer Completeness (`executeSweep`)
+
+- [ ] Confirm that `SweepController.execute_sweep()` / `EphemeralAccount.sweep()` still updates state and emits events but does **not** execute token transfers on-chain.
+- [ ] Confirm that the SDK's `executeSweep()` method in `stellar.service.ts` does not assume tokens have moved when logging success.
+- [ ] Confirm the contract error mapping (AlreadySwept, AccountExpired, UnauthorizedDestination, AuthorizationFailed) still matches the current bridgelet-core error set.
+
+### 3. Fund Recovery Completeness (`expireAccount`)
+
+- [ ] Confirm that `EphemeralAccount.expire()` still does not perform actual token transfers to `recovery_address` because bridgelet-core token transfer is incomplete.
+- [ ] Confirm the SDK's `expireAccount()` method in `stellar.service.ts` does not assume funds have been recovered when logging success.
+- [ ] Confirm the contract error mapping (NotExpired, InvalidStatus, NotInitialized) still matches the current bridgelet-core error set.
+
+## Re-verification Triggers
+
+Re-run this checklist when any of the following occur:
+
+- A new version of `bridgelet-core` contracts is deployed to testnet or mainnet.
+- The `stellar.service.ts` contract-call methods are refactored or their transaction structure changes.
+- The `sweep-controller-mvp-note-accuracy.md` runbook (when created) flags a drift.
+- An integrator reports behavior inconsistent with an MVP note's description.
+
+## Recording Results
+
+After each sweep, update the "last verified" date below. If a note is found stale, open a new postmortem issue in the audit repository and update or remove the `⚠️ MVP Note` comment in source.
+
+| MVP Note | Last Verified | Status |
+| --- | --- | --- |
+| Horizon-Soroban Non-Atomicity | | |
+| Token Transfer Completeness | | |
+| Fund Recovery Completeness | | |

--- a/bridgelet-sdk-audit/postmortems/horizon-soroban-non-atomicity.md
+++ b/bridgelet-sdk-audit/postmortems/horizon-soroban-non-atomicity.md
@@ -1,0 +1,28 @@
+# Postmortem: Horizon-Soroban Non-Atomicity in Account Creation
+
+## Issue Summary
+
+Creating an ephemeral account requires two independent ledger operations—a Horizon `CreateAccount` and a Soroban `EphemeralAccount.initialize()` call—that cannot be committed atomically. A failure between the two leaves an unrestricted, funded account on-chain with no contract restrictions.
+
+## Root Cause
+
+Stellar's Horizon (classic ledger) and Soroban (smart-contract layer) are separate systems with independent transaction pipelines. The SDK's `createEphemeralAccount()` flow in `stellar.service.ts:180` performs these as two discrete steps:
+
+1. **Horizon:** `CreateAccount` operation funds the new public key with the 2 XLM base reserve.
+2. **Soroban:** `EphemeralAccount.initialize()` is called to set expiry, recovery address, and sweep controller restrictions on-chain.
+
+Because there is no cross-system atomic commit, a failure at step 2 (RPC timeout, invalid expiry ledger, network partition, contract already initialized) after step 1 succeeds results in an orphaned account: a funded Stellar classic account that has no Soroban contract backing it, meaning no expiry, no recovery mechanism, and no sweep restrictions apply.
+
+The concrete failure window an operator observes:
+
+- **Step 1 succeeded:** Horizon returns a successful `CreateAccount` transaction; the account holds 2 XLM on the classic ledger.
+- **Step 2 failed:** The Soroban RPC rejects or times out on `initialize()`.
+- **Resulting state:** An unrestricted account exists on-chain. It cannot be swept (no contract to call), cannot expire (no expiry ledger), and can only be recovered via manual account-merge back to the funding keypair.
+
+The SDK throws an error to prevent persisting a database record for the unrestricted account, but the on-chain orphan remains and requires manual intervention.
+
+This is the class of problem described as internal Issue #15, which tracks the compensation strategy for orphaned accounts. The failure runbook at `bridgelet-sdk-audit/runbooks/diagnose-failed-account-creation.md` documents the triage steps.
+
+## Resolution
+
+The current mitigation is defensive: the SDK prevents database persistence of uninitialized accounts and the cleanup scheduler marks stuck `INITIALIZING` records as `FAILED` after a timeout. The orphaned on-chain account itself requires manual account-merge remediation (documented in the runbook). A proper resolution—either an on-chain compensating transaction or a protocol-level two-phase commit—remains tracked as Issue #15 and is outside the scope of the SDK MVP.

--- a/bridgelet-sdk-audit/postmortems/postmortems-index.md
+++ b/bridgelet-sdk-audit/postmortems/postmortems-index.md
@@ -5,5 +5,6 @@ This directory archives postmortems and lessons learned from past incidents invo
 - [Overlapping Payment Monitor Ticks](./overlapping-payment-monitor-ticks.md)
 - [Webhook vs Confirmation Ordering](./webhook-vs-confirmation-ordering.md)
 - [Tight Coupling in getAccountInfo() Parsing](./getinfo-parsing-coupling.md)
+- [Horizon-Soroban Non-Atomicity in Account Creation](./horizon-soroban-non-atomicity.md)
 
 Use the [Postmortem Template](./postmortem-template.md) to add new entries.


### PR DESCRIPTION
Closes #328
Closes #329

Adds the two documentation-only deliverables assigned to Gracora:

- **Postmortem** (): covers the general problem class of composing two independent ledgers without a shared atomic commit, walks through the concrete failure window in , and notes why an MVP comment is worth its own tracked writeup.
- **Checklist** (): inventories all three  comments in  and provides verification items for each, plus re-verification triggers and a results-recording table.

Both index files (, ) are updated to include the new entries.