### PR TITLE
docs: add postmortems for eslint scope, prettierignore, and i128 encoding

### DIFF
--- a/bridgelet-sdk-audit/postmortems/eslint-lint-script-scope.md
+++ b/bridgelet-sdk-audit/postmortems/eslint-lint-script-scope.md
@@ -1,0 +1,30 @@
+# Postmortem: ESLint Lint Script Scope
+
+## Issue Summary
+
+The `lint` script in `package.json` uses an explicit glob that only targets TypeScript files within specific directories, leaving many project files outside ESLint's reach. Contributors may assume the lint command covers the entire repository, leading to uncaught issues in overlooked paths.
+
+## Root Cause
+
+The lint script is defined as:
+
+```
+eslint "{src,apps,libs,test}/**/*.ts" --fix
+```
+
+This glob explicitly restricts linting to `*.ts` files inside `src/`, `apps/`, `libs/`, and `test/`. Files that fall outside this scope include:
+
+- Root-level configuration files (`*.js`, `*.json`, `*.ts` at the project root)
+- Non-TypeScript source files (`*.md`, `*.yml`, `*.yaml`, `*.sh`, `*.css`)
+- Any TypeScript files in directories not listed in the glob (e.g., `scripts/`, `bridgelet-sdk-audit/`)
+
+A contributor unfamiliar with this detail might run `npm run lint` expecting comprehensive coverage and believe the codebase is clean, when in fact files outside the glob are never checked.
+
+## Resolution
+
+No code change is required; this is a documentation-only finding. The lint script's glob is intentional—it keeps lint fast and focused on application code. The important takeaway is that contributors should be aware of the script's actual scope rather than assuming it covers the full repository.
+
+## Action Items
+
+- [ ] Add a comment in `package.json` or a note in `CONTRIBUTING.md` clarifying the lint script's explicit glob scope.
+- [ ] Consider whether additional scripts or a broader ESLint config (e.g., `.eslintrc` with `ignorePatterns`) would benefit the project as it grows.

--- a/bridgelet-sdk-audit/postmortems/i128-encoding-manual-implementation.md
+++ b/bridgelet-sdk-audit/postmortems/i128-encoding-manual-implementation.md
@@ -1,0 +1,39 @@
+# Postmortem: Hand-Rolled i128 Bit-Splitting for Contract Calls
+
+## Issue Summary
+
+The SDK uses a manually written hi/lo bit-split to encode `bigint` values as Soroban `i128` parameters for the `record_payment` contract call. This hand-rolled encoding is inlined at a single call site rather than centralized in a reusable helper, creating a maintenance risk as more contract calls are added.
+
+## Root Cause
+
+In `src/modules/stellar/stellar.service.ts`, the `recordPayment()` method constructs the `i128` XDR value by splitting a `bigint` into high and low 64-bit parts:
+
+```typescript
+StellarSdk.xdr.Int128Parts({
+  hi: StellarSdk.xdr.Int64.fromString(
+    (params.amount >> 64n).toString(),
+  ),
+  lo: StellarSdk.xdr.Uint64.fromString(
+    (params.amount & 0xffffffffffffffffn).toString(),
+  ),
+}),
+```
+
+What could go wrong:
+
+- **Sign assumptions**: If a negative amount were ever passed, the right-shift and mask operations would produce incorrect two's-complement representation, resulting in a silently wrong value on-chain.
+- **Magnitude overflow**: A value exceeding 128 bits would silently truncate during the shift/mask, producing an incorrect encoding without any runtime error.
+- **Duplication**: As more contract calls accept `i128` parameters, each call site would need to re-implement this same logic, multiplying the risk of inconsistency.
+
+Today the blast radius is contained—there is exactly one call site (`recordPayment`), and the amount is always a positive stroop value derived from a Horizon decimal string. But this is a fragile assumption.
+
+## Resolution
+
+No code change is required for the immediate finding; the current implementation is correct for its single call site. The key recommendation is to centralize the i128 encoding into a single, well-tested helper function so that future call sites do not duplicate the bit-splitting logic.
+
+## Action Items
+
+- [ ] Extract the i128 encoding into a shared utility (e.g., `encodeI128(value: bigint): StellarSdk.xdr.Int128Parts`).
+- [ ] Add validation in the helper to reject negative values or values exceeding 128-bit range.
+- [ ] Add unit tests covering edge cases: zero, maximum positive i128, minimum positive value, and boundary values near the 64-bit boundary.
+- [ ] Refactor `recordPayment()` to use the new helper.

--- a/bridgelet-sdk-audit/postmortems/no-prettierignore-full-repo-scan.md
+++ b/bridgelet-sdk-audit/postmortems/no-prettierignore-full-repo-scan.md
@@ -1,0 +1,29 @@
+# Postmortem: No .prettierignore — Full Repository Scan
+
+## Issue Summary
+
+The `format:check` script runs `prettier --check .`, which scans the entire repository for formatting violations. The project has no `.prettierignore` file, meaning every file—including documentation, generated artifacts, and third-party content—is subject to Prettier's formatting rules.
+
+## Root Cause
+
+Without a `.prettierignore`, Prettier treats the current directory (`.`) as its full scope. This means:
+
+- Markdown files (`*.md`), YAML configs (`*.yml`), and other non-code files are checked and may fail formatting if they contain intentionally formatted content.
+- Any generated artifacts or vendored files committed to the repository will be scanned, potentially producing noisy failures.
+- Contributors adding new documentation or configuration files may be surprised by unexpected formatting requirements.
+
+In practice this can slow down CI and create friction for contributors who add files that were not intended to be formatted.
+
+## Resolution
+
+This is a documentation-only finding. Whether to add a `.prettierignore` depends on the project's goals:
+
+- **Adding `.prettierignore`** is worthwhile when the repository contains files where formatting consistency is not important (e.g., `*.lock`, generated files, vendored assets) or where Prettier's output would be undesirable.
+- **Keeping full-repo formatting** is a valid default for small, well-curated repositories where consistency across all files is valued and the scan cost is negligible.
+
+The decision should be documented so future contributors understand the expectation.
+
+## Action Items
+
+- [ ] Decide whether a `.prettierignore` is appropriate for this repository and add one if so.
+- [ ] Document the formatting scope expectation in `CONTRIBUTING.md` or a similar guide.

--- a/bridgelet-sdk-audit/postmortems/postmortems-index.md
+++ b/bridgelet-sdk-audit/postmortems/postmortems-index.md
@@ -5,5 +5,8 @@ This directory archives postmortems and lessons learned from past incidents invo
 - [Overlapping Payment Monitor Ticks](./overlapping-payment-monitor-ticks.md)
 - [Webhook vs Confirmation Ordering](./webhook-vs-confirmation-ordering.md)
 - [Tight Coupling in getAccountInfo() Parsing](./getinfo-parsing-coupling.md)
+- [ESLint Lint Script Scope](./eslint-lint-script-scope.md)
+- [No .prettierignore — Full Repository Scan](./no-prettierignore-full-repo-scan.md)
+- [Hand-Rolled i128 Bit-Splitting for Contract Calls](./i128-encoding-manual-implementation.md)
 
 Use the [Postmortem Template](./postmortem-template.md) to add new entries.


### PR DESCRIPTION
Closes #344
Closes #343
Closes #340

Adds three postmortem articles to the audit knowledge base:

- **eslint-lint-script-scope** (#344): Documents the explicit glob in the lint script and what falls outside its scope.
- **no-prettierignore-full-repo-scan** (#343): Documents the absence of a .prettierignore and its implications for full-repo formatting checks.
- **i128-encoding-manual-implementation** (#340): Documents the hand-rolled i128 bit-splitting in recordPayment() and recommends centralizing the logic.