### PR TITLE
docs: add postmortems for sweeps, accounts, simulation, and config

### DIFF
--- a/bridgelet-sdk-audit/postmortems/accounts-future-auth-scoping-note.md
+++ b/bridgelet-sdk-audit/postmortems/accounts-future-auth-scoping-note.md
@@ -1,0 +1,7 @@
+# Postmortem: Accounts Future Auth Scoping Note
+**Path:** `bridgelet-sdk-audit/postmortems/accounts-future-auth-scoping-note.md`
+
+## Overview
+The `FUTURE_AUTH_SCOPING.md` note in the accounts module incorrectly referenced deprecated authentication patterns, leading to integration delays when planning for role-based access.
+## Fix
+Removed deprecated patterns and updated the note to align with current Soroban auth scopes.

--- a/bridgelet-sdk-audit/postmortems/config-getorthrow-fail-fast-pattern.md
+++ b/bridgelet-sdk-audit/postmortems/config-getorthrow-fail-fast-pattern.md
@@ -1,0 +1,7 @@
+# Postmortem: ConfigService getOrThrow Fail-Fast Pattern
+**Path:** `bridgelet-sdk-audit/postmortems/config-getorthrow-fail-fast-pattern.md`
+
+## Overview
+The contract-consumption layer incorrectly caught configuration errors silently instead of failing fast using `ConfigService.getOrThrow`. This masked missing environment variables until deeply nested contract calls failed with opaque errors.
+## Fix
+Enforced the fail-fast pattern by utilizing `getOrThrow` uniformly across all provider initializations.

--- a/bridgelet-sdk-audit/postmortems/sourceaccount-dummy-keypair-for-simulation.md
+++ b/bridgelet-sdk-audit/postmortems/sourceaccount-dummy-keypair-for-simulation.md
@@ -1,0 +1,7 @@
+# Postmortem: Dummy Keypair for Simulation
+**Path:** `bridgelet-sdk-audit/postmortems/sourceaccount-dummy-keypair-for-simulation.md`
+
+## Overview
+Using a random dummy keypair as the source account for read-only simulation calls works well on testnets, but causes issues when simulating large transactions due to sequence number mismatches or minimum balance constraints on the dummy account.
+## Fix
+Adopted a static simulation account with high balance exclusively for read-only state checks.

--- a/bridgelet-sdk-audit/postmortems/sweeps-readme-scope.md
+++ b/bridgelet-sdk-audit/postmortems/sweeps-readme-scope.md
@@ -1,0 +1,7 @@
+# Postmortem: Sweeps README Scope Mismatch
+**Path:** `bridgelet-sdk-audit/postmortems/sweeps-readme-scope.md`
+
+## Overview
+The `src/modules/sweeps/README.md` file documented the sweeps module as a monolith, failing to explain the actual provider breakdown (e.g., NativeAuth vs. Relayer mechanisms). This caused confusion during integration.
+## Fix
+Updated the documentation to properly index the provider abstractions.


### PR DESCRIPTION
closes #351, closes #350, closes #349, closes #348